### PR TITLE
core: define stream id types

### DIFF
--- a/core/src/main/scala/sec/Main.scala
+++ b/core/src/main/scala/sec/Main.scala
@@ -36,7 +36,7 @@ object Main extends IOApp {
     }
 
     for {
-      streamId   <- Stream.eval(uuid[F].map(id => s"test_stream-$id"))
+      streamId   <- Stream.eval(uuid[F] >>= (id => StreamId[F](s"test_stream-$id")))
       eventData1 <- Stream.eval(data.map(l => NonEmptyList(l.head, l.tail)).orFail[F])
       eventData2 <- Stream.eval(data.map(l => NonEmptyList(l.head, l.tail)).orFail[F])
       _          <- Stream.eval(client.appendToStream(streamId, NoStream, eventData1)).evalTap(print[F])
@@ -47,46 +47,57 @@ object Main extends IOApp {
 
   def run2[F[_]: ConcurrentEffect: Timer](client: Streams[F]): Stream[F, Unit] = {
 
-    val sid   = s"not-here-${UUID.randomUUID()}"
-    val sub   = client.subscribeToStream(sid, Some(EventNumber.Start)).evalMap(print[F])
-    val event = (Content.json(f"""{ "a" : "b" }""") >>= (j => EventData("test", UUID.randomUUID(), j))).orFail[F]
-    val app   = Stream.eval(event >>= (e => client.appendToStream(sid, NoStream, NonEmptyList.one(e)))).delayBy(5.second)
+    val streamId           = StreamId[F](s"not-here-${UUID.randomUUID()}")
+    def sub(sid: StreamId) = client.subscribeToStream(sid, Some(EventNumber.Start)).evalMap(print[F])
+    val event              = (Content.json(f"""{ "a" : "b" }""") >>= (j => EventData("test", UUID.randomUUID(), j))).orFail[F]
+    def app(id: StreamId)  = Stream.eval(event >>= (e => client.appendToStream(id, NoStream, NonEmptyList.one(e))))
 
     // subscribeToStream works when stream does not exist.
     // I guess I have to start writing tests soon :)
-    sub.concurrently(app)
+
+    Stream.eval(streamId) >>= { sid =>
+      sub(sid).concurrently(app(sid).delayBy(5.second))
+    }
+
   }
 
   def run3[F[_]: ConcurrentEffect](client: Streams[F]): Stream[F, Unit] =
     client.readAllBackwards(Position.End, 1).take(1).evalTap(print[F]).void
 
   def run4[F[_]: ConcurrentEffect](client: Streams[F]): Stream[F, Unit] =
-    client.readStreamBackwards("$users", EventNumber.End, 1).take(1).evalTap(print[F]).void
+    Stream.eval(StreamId[F]("$users")) >>= { sid =>
+      client
+        .readStreamBackwards(sid, EventNumber.End, 1)
+        .take(1)
+        .evalTap(print[F])
+        .void
+    }
 
   def run5[F[_]](client: Streams[F])(implicit F: ConcurrentEffect[F]): Stream[F, Unit] = {
 
-    val sid    = s"delete-${UUID.randomUUID()}"
-    val event  = (Content.json(f"""{ "de" : "l" }""") >>= (j => EventData("test", UUID.randomUUID(), j))).orFail[F]
-    val append = Stream.eval(event >>= (e => client.appendToStream(sid, NoStream, NonEmptyList.one(e))))
-    val read   = client.readStreamForwards(sid, EventNumber.Start, 1).take(1).evalTap(print[F]).void
-    val delete = Stream.eval(client.softDelete(sid, EventNumber.Start))
+    val streamId              = StreamId[F](s"delete-${UUID.randomUUID()}")
+    val event                 = (Content.json(f"""{ "de" : "l" }""") >>= (j => EventData("test", UUID.randomUUID(), j))).orFail[F]
+    def append(sid: StreamId) = Stream.eval(event >>= (e => client.appendToStream(sid, NoStream, NonEmptyList.one(e))))
+    def read(sid: StreamId)   = client.readStreamForwards(sid, EventNumber.Start, 1).take(1).evalTap(print[F]).void
+    def delete(sid: StreamId) = Stream.eval(client.softDelete(sid, EventNumber.Start))
 
     for {
-      _ <- append
-      _ <- read
-      _ <- delete
-      _ <- read.recoverWith {
+      sid <- Stream.eval(streamId)
+      _   <- append(sid)
+      _   <- read(sid)
+      _   <- delete(sid)
+      _ <- read(sid).recoverWith {
             case snf: StreamNotFound =>
               Stream
                 .eval(client.metadata.getStreamMetadata(sid, None))
                 .collect { case Some(v) => v.data.truncateBefore.fold(0L)(_.value) }
                 .evalMap { n =>
-                  if (n == Long.MaxValue) F.raiseError(StreamDeleted(sid)) else F.raiseError(snf)
+                  if (n == Long.MaxValue) F.raiseError(StreamDeleted(sid.stringValue)) else F.raiseError(snf)
                 }
                 .void
           }
-      _ <- append
-      _ <- read
+      _ <- append(sid)
+      _ <- read(sid)
     } yield ()
 
   }

--- a/core/src/main/scala/sec/core/constants.scala
+++ b/core/src/main/scala/sec/core/constants.scala
@@ -26,16 +26,4 @@ private[sec] object constants {
 
 //======================================================================================================================
 
-  object SystemStreams {
-
-    final val StreamsStream: String                   = "$streams"
-    final val SettingsStream: String                  = "$settings"
-    final val UsersPasswordNotificationStream: String = "$users-password-notifications"
-    final val StatsStream: String                     = "$stats"
-
-    final val MetadataPrefix: String = "$$"
-  }
-
-//======================================================================================================================
-
 }

--- a/core/src/main/scala/sec/core/exceptions.scala
+++ b/core/src/main/scala/sec/core/exceptions.scala
@@ -3,11 +3,11 @@ package core
 
 sealed abstract class EsException(msg: String) extends RuntimeException(msg)
 
-case object AccessDenied                            extends EsException("Access Denied.")                             // All
-case object InvalidTransaction                      extends EsException("Invalid Transaction.")                       // Streams.Delete + Streams.Append
-final case class UserNotFound(loginName: String)    extends EsException(s"User '$loginName' was not found.")          // Users
-final case class StreamDeleted(streamName: String)  extends EsException(s"Event stream '$streamName' is deleted.")    // Streams
-final case class StreamNotFound(streamName: String) extends EsException(s"Event stream '$streamName' was not found.") // Streams.Read/Subscribe
+case object AccessDenied                          extends EsException("Access Denied.")                           // All
+case object InvalidTransaction                    extends EsException("Invalid Transaction.")                     // Streams.Delete + Streams.Append
+final case class UserNotFound(loginName: String)  extends EsException(s"User '$loginName' was not found.")        // Users
+final case class StreamDeleted(streamId: String)  extends EsException(s"Event stream '$streamId' is deleted.")    // Streams
+final case class StreamNotFound(streamId: String) extends EsException(s"Event stream '$streamId' was not found.") // Streams.Read/Subscribe
 
 final case class MaximumAppendSizeExceeded(size: Option[Int]) extends EsException(MaximumAppendSizeExceeded.msg(size)) // Streams.Append
 
@@ -16,28 +16,28 @@ object MaximumAppendSizeExceeded {
     s"Maximum append size ${maxSize.map(max => s"of $max bytes ").getOrElse("")}exceeded."
 }
 
-final case class WrongExpectedVersion(streamName: String, expected: Option[Long], actual: Option[Long]) // Streams.Delete + Streams.Append
-  extends EsException(WrongExpectedVersion.msg(streamName, expected, actual))
+final case class WrongExpectedVersion(streamId: String, expected: Option[Long], actual: Option[Long]) // Streams.Delete + Streams.Append
+  extends EsException(WrongExpectedVersion.msg(streamId, expected, actual))
 
 object WrongExpectedVersion {
-  def msg(streamName: String, expected: Option[Long], actual: Option[Long]): String = {
+  def msg(streamId: String, expected: Option[Long], actual: Option[Long]): String = {
     val exp = expected.getOrElse("<unknown>")
     val act = actual.getOrElse("<unknown>")
-    s"WrongExpectedVersion for stream: $streamName, expected version: $exp, actual version: $act"
+    s"WrongExpectedVersion for stream: $streamId, expected version: $exp, actual version: $act"
   }
 }
 
-final case class PersistentSubscriptionFailed(streamName: String, groupName: String, reason: String)
-  extends EsException(s"Subscription group $groupName on stream $streamName failed: '$reason'.")
+final case class PersistentSubscriptionFailed(streamId: String, groupName: String, reason: String)
+  extends EsException(s"Subscription group $groupName on stream $streamId failed: '$reason'.")
 
-final case class PersistentSubscriptionExists(streamName: String, groupName: String)
-  extends EsException(s"Subscription group $groupName on stream $streamName exists.")
+final case class PersistentSubscriptionExists(streamId: String, groupName: String)
+  extends EsException(s"Subscription group $groupName on stream $streamId exists.")
 
-final case class PersistentSubscriptionNotFound(streamName: String, groupName: String)
-  extends EsException(s"Subscription group '$groupName' on stream '$streamName' does not exist.")
+final case class PersistentSubscriptionNotFound(streamId: String, groupName: String)
+  extends EsException(s"Subscription group '$groupName' on stream '$streamId' does not exist.")
 
-final case class PersistentSubscriptionDroppedByServer(streamName: String, groupName: String)
-  extends EsException(s"Subscription group '$groupName' on stream '$streamName' was dropped.")
+final case class PersistentSubscriptionDroppedByServer(streamId: String, groupName: String)
+  extends EsException(s"Subscription group '$groupName' on stream '$streamId' was dropped.")
 
-final case class PersistentSubscriptionMaximumSubscribersReached(streamName: String, groupName: String)
-  extends EsException(s"Maximum subscriptions reached for subscription group '$groupName' on stream '$streamName.'")
+final case class PersistentSubscriptionMaximumSubscribersReached(streamId: String, groupName: String)
+  extends EsException(s"Maximum subscriptions reached for subscription group '$groupName' on stream '$streamId.'")

--- a/core/src/main/scala/sec/core/id.scala
+++ b/core/src/main/scala/sec/core/id.scala
@@ -1,0 +1,114 @@
+package sec
+package core
+
+import cats.{ApplicativeError, Eq, Show}
+import cats.implicits._
+
+//======================================================================================================================
+
+sealed trait StreamId
+object StreamId {
+
+  sealed trait Id       extends StreamId
+  sealed trait NormalId extends Id
+  sealed trait SystemId extends Id
+
+  final case class MetaId(id: Id) extends StreamId
+
+  case object PersistentSubscriptionConfig extends SystemId
+  case object All                          extends SystemId
+  case object Settings                     extends SystemId
+  case object Stats                        extends SystemId
+  case object Streams                      extends SystemId
+  case object UsersPasswordNotifications   extends SystemId
+
+  sealed abstract case class System(name: String) extends SystemId
+  sealed abstract case class Normal(name: String) extends NormalId
+
+  def apply[F[_]](name: String)(implicit F: ApplicativeError[F, Throwable]): F[Id] =
+    from(name).leftMap(StreamIdError).liftTo[F]
+
+  def from(name: String): Attempt[Id] = {
+    guardNonEmptyName(name) >>= guardNotStartWith(metadataPrefix) >>= { n =>
+      if (n.startsWith(systemPrefix)) system(n.substring(1)) else normal(n)
+    }
+  }
+
+  final case class StreamIdError(msg: String) extends RuntimeException(msg)
+
+  ///
+
+  private val guardNonEmptyName: String => Attempt[String] = guardNonEmpty("name")
+  private def guardNotStartWith(prefix: String): String => Attempt[String] =
+    n => Either.cond(!n.startsWith(prefix), n, s"name must not start with $prefix, but is $n")
+
+  private[sec] def normal(name: String): Attempt[Normal] =
+    (guardNonEmptyName(name) >>= guardNotStartWith(systemPrefix)).map(new Normal(_) {})
+
+  private[sec] def system(name: String): Attempt[System] =
+    (guardNonEmptyName(name) >>= guardNotStartWith(systemPrefix)).map(new System(_) {})
+
+  ///
+
+  private[sec] val streamIdToString: StreamId => String = {
+    case id: Id     => idToString(id)
+    case MetaId(id) => s"$metadataPrefix${idToString(id)}"
+  }
+
+  private[sec] val stringToStreamId: String => Attempt[StreamId] = {
+    case id if id.startsWith(metadataPrefix) => stringToId(id.substring(2)).map(MetaId)
+    case id                                  => stringToId(id)
+  }
+
+  private[sec] val idToString: Id => String = {
+    case PersistentSubscriptionConfig => systemStreams.PersistentSubscriptionConfig
+    case All                          => systemStreams.All
+    case Settings                     => systemStreams.Settings
+    case Stats                        => systemStreams.Stats
+    case Streams                      => systemStreams.Streams
+    case UsersPasswordNotifications   => systemStreams.UsersPasswordNotifications
+    case System(n)                    => s"$systemPrefix$n"
+    case Normal(n)                    => n
+  }
+
+  private[sec] val stringToId: String => Attempt[Id] = {
+    case systemStreams.PersistentSubscriptionConfig => PersistentSubscriptionConfig.asRight
+    case systemStreams.All                          => All.asRight
+    case systemStreams.Settings                     => Settings.asRight
+    case systemStreams.Streams                      => Streams.asRight
+    case systemStreams.UsersPasswordNotifications   => UsersPasswordNotifications.asRight
+    case sid if sid.startsWith(systemPrefix)        => system(sid.substring(1))
+    case sid                                        => normal(sid)
+  }
+
+  private[sec] val systemPrefix: String   = "$"
+  private[sec] val metadataPrefix: String = "$$"
+
+  private object systemStreams {
+
+    final val PersistentSubscriptionConfig       = "$persistentSubscriptionConfig"
+    final val All: String                        = "$all"
+    final val Settings: String                   = "$settings"
+    final val Stats: String                      = "$stats"
+    final val Scavenges: String                  = "$scavenges"
+    final val Streams: String                    = "$streams"
+    final val UsersPasswordNotifications: String = "$users-password-notifications"
+
+  }
+
+  ///
+
+  implicit final class StreamIdOps(val sid: StreamId) extends AnyVal {
+    def stringValue: String = streamIdToString(sid)
+  }
+
+  implicit final class IdOps(val id: Id) extends AnyVal {
+    def meta: MetaId = MetaId(id)
+  }
+
+  implicit val eqForStreamId: Eq[StreamId]     = Eq.fromUniversalEquals[StreamId]
+  implicit val showForStreamId: Show[StreamId] = Show.show[StreamId](_.stringValue)
+
+}
+
+//======================================================================================================================

--- a/core/src/main/scala/sec/package.scala
+++ b/core/src/main/scala/sec/package.scala
@@ -1,8 +1,13 @@
+import cats.implicits._
+
 package object sec {
 
 //======================================================================================================================
 
   private[sec] type Attempt[T] = Either[String, T]
+
+  private[sec] def guardNonEmpty(param: String): String => Attempt[String] =
+    p => Either.fromOption(Option(p).filter(_.nonEmpty), s"$param cannot be empty")
 
 //======================================================================================================================
 

--- a/core/src/main/scala/sec/syntax/streams.scala
+++ b/core/src/main/scala/sec/syntax/streams.scala
@@ -3,7 +3,7 @@ package syntax
 
 import cats.data.NonEmptyList
 import fs2.Stream
-import sec.core.{Event, EventData, EventFilter, EventNumber, Position, StreamRevision}
+import sec.core.{Event, EventData, EventFilter, EventNumber, Position, StreamId, StreamRevision}
 import sec.api._
 
 final class StreamsSyntax[F[_]](val s: Streams[F]) extends AnyVal {
@@ -19,33 +19,33 @@ final class StreamsSyntax[F[_]](val s: Streams[F]) extends AnyVal {
     s.subscribeToAll(exclusiveFrom, resolveLinkTos, filter, credentials)
 
   def subscribeToStream(
-    stream: String,
+    streamId: StreamId,
     exclusiveFrom: Option[EventNumber],
     resolveLinkTos: Boolean = false,
     failIfNotFound: Boolean = false,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.subscribeToStream(stream, exclusiveFrom, resolveLinkTos, failIfNotFound, credentials)
+    s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos, failIfNotFound, credentials)
 
   /// Read
 
   def readStreamForwards(
-    stream: String,
+    streamId: StreamId,
     from: EventNumber,
     count: Int,
     resolveLinkTos: Boolean = false,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.readStream(stream, ReadDirection.Forward, from, count, resolveLinkTos, credentials)
+    s.readStream(streamId, ReadDirection.Forward, from, count, resolveLinkTos, credentials)
 
   def readStreamBackwards(
-    stream: String,
+    streamId: StreamId,
     from: EventNumber,
     count: Int,
     resolveLinkTos: Boolean = false,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.readStream(stream, ReadDirection.Backward, from, count, resolveLinkTos, credentials)
+    s.readStream(streamId, ReadDirection.Backward, from, count, resolveLinkTos, credentials)
 
   def readAllForwards(
     position: Position,
@@ -68,27 +68,27 @@ final class StreamsSyntax[F[_]](val s: Streams[F]) extends AnyVal {
   /// Append
 
   def appendToStream(
-    stream: String,
+    streamId: StreamId,
     expectedRevision: StreamRevision,
     events: NonEmptyList[EventData],
     credentials: Option[UserCredentials] = None
   ): F[Streams.WriteResult] =
-    s.appendToStream(stream, expectedRevision, events, credentials)
+    s.appendToStream(streamId, expectedRevision, events, credentials)
 
   /// Delete
 
   def softDelete(
-    stream: String,
+    streamId: StreamId,
     expectedRevision: StreamRevision,
     credentials: Option[UserCredentials] = None
   ): F[Streams.DeleteResult] =
-    s.softDelete(stream, expectedRevision, credentials)
+    s.softDelete(streamId, expectedRevision, credentials)
 
   def hardDelete(
-    stream: String,
+    streamId: StreamId,
     expectedRevision: StreamRevision,
     credentials: Option[UserCredentials] = None
   ): F[Streams.DeleteResult] =
-    s.hardDelete(stream, expectedRevision, credentials)
+    s.hardDelete(streamId, expectedRevision, credentials)
 
 }


### PR DESCRIPTION
 - define `StreamId` in order to get better
   guarantees with respect to different kinds
   of streams, i.e. metadata, system and normal
   streams.

 - eventtype: minor refactorings