### PR TITLE
api: make subscriptions more resilient

### DIFF
--- a/core/src/main/scala/sec/Main.scala
+++ b/core/src/main/scala/sec/Main.scala
@@ -24,7 +24,7 @@ object Main extends IOApp {
     val result: Stream[IO, Unit] = for {
       builder <- Stream.eval(nettyBuilder[IO])
       client  <- EsClient.stream[IO, NettyChannelBuilder](builder, Options.default).map(_.streams)
-      _       <- run6[IO](client)
+      _       <- run2[IO](client)
     } yield ()
 
     result.compile.drain.as(ExitCode.Success)

--- a/core/src/main/scala/sec/api/grpc/package.scala
+++ b/core/src/main/scala/sec/api/grpc/package.scala
@@ -2,7 +2,7 @@ package sec
 package api
 
 import cats.implicits._
-import io.grpc.{Metadata, StatusRuntimeException}
+import io.grpc.{Metadata, Status, StatusRuntimeException}
 import sec.core._
 import grpc.constants.Headers._
 import grpc.constants.{Exceptions => ce}
@@ -29,6 +29,7 @@ package object grpc {
 
     val unknown           = "<unknown>"
     val md                = ex.getTrailers
+    val status            = ex.getStatus()
     val exception         = md.getOpt(keys.exception)
     def streamName        = md.getOpt(keys.streamName).getOrElse(unknown)
     def groupName         = md.getOpt(keys.groupName).getOrElse(unknown)
@@ -37,7 +38,7 @@ package object grpc {
     def loginName         = md.getOpt(keys.loginName).getOrElse(unknown)
     def maximumAppendSize = md.getOpt(keys.maximumAppendSize)
 
-    exception.map {
+    val reified: Option[EsException] = exception.map {
       case ce.AccessDenied                       => AccessDenied
       case ce.InvalidTransaction                 => InvalidTransaction
       case ce.MaximumAppendSizeExceeded          => MaximumAppendSizeExceeded(maximumAppendSize)
@@ -48,7 +49,14 @@ package object grpc {
       case ce.MaximumSubscribersReached          => PersistentSubscriptionMaximumSubscribersReached(streamName, groupName)
       case ce.PersistentSubscriptionDropped      => PersistentSubscriptionDroppedByServer(streamName, groupName)
       case ce.UserNotFound                       => UserNotFound(loginName)
+      case unknown                               => UnknownError(s"Exception key: $unknown")
     }
+
+    def serverUnavailable: Option[EsException] = Option.when(status.getCode == Status.Code.UNAVAILABLE)(
+      ServerUnavailable(Option(ex.getMessage()).getOrElse("Server unavailable"))
+    )
+
+    reified orElse serverUnavailable
   }
 
 //======================================================================================================================

--- a/core/src/main/scala/sec/core/exceptions.scala
+++ b/core/src/main/scala/sec/core/exceptions.scala
@@ -3,11 +3,13 @@ package core
 
 sealed abstract class EsException(msg: String) extends RuntimeException(msg)
 
-case object AccessDenied                          extends EsException("Access Denied.")                           // All
-case object InvalidTransaction                    extends EsException("Invalid Transaction.")                     // Streams.Delete + Streams.Append
-final case class UserNotFound(loginName: String)  extends EsException(s"User '$loginName' was not found.")        // Users
-final case class StreamDeleted(streamId: String)  extends EsException(s"Event stream '$streamId' is deleted.")    // Streams
+case object AccessDenied                          extends EsException("Access Denied.") // All
+case object InvalidTransaction                    extends EsException("Invalid Transaction.") // Streams.Delete + Streams.Append
+final case class UserNotFound(loginName: String)  extends EsException(s"User '$loginName' was not found.") // Users
+final case class StreamDeleted(streamId: String)  extends EsException(s"Event stream '$streamId' is deleted.") // Streams
 final case class StreamNotFound(streamId: String) extends EsException(s"Event stream '$streamId' was not found.") // Streams.Read/Subscribe
+final case class UnknownError(msg: String)        extends EsException(msg)
+final case class ServerUnavailable(msg: String)   extends EsException(msg)
 
 final case class MaximumAppendSizeExceeded(size: Option[Int]) extends EsException(MaximumAppendSizeExceeded.msg(size)) // Streams.Append
 

--- a/core/src/main/scala/sec/core/version.scala
+++ b/core/src/main/scala/sec/core/version.scala
@@ -46,11 +46,13 @@ object EventNumber {
   def apply(number: Long): EventNumber = if (number < 0) End else exact(number)
 
   implicit val orderForEventNumber: Order[EventNumber] = Order.from {
-    case (x: Exact, y: Exact) => x.value compare y.value
+    case (x: Exact, y: Exact) => Order[Exact].compare(x, y)
     case (_: Exact, End)      => -1
     case (End, _: Exact)      => 1
     case (End, End)           => 0
   }
+
+  implicit val orderForExact: Order[Exact] = Order.by(_.value)
 
   implicit val showForExact: Show[Exact] = Show.show[Exact] {
     case Exact(v) => s"EventNumber($v)"

--- a/core/src/test/scala/sec/api/grpc/package.scala
+++ b/core/src/test/scala/sec/api/grpc/package.scala
@@ -128,5 +128,15 @@ class GrpcPackageSpec extends mutable.Specification {
       m.put(ek, ce.UserNotFound)
     } should beSome(UserNotFound(unknown))
 
+    /// Unknown Exception Key
+
+    convert { m =>
+      m.put(ek, "not-handled")
+    } should beSome(UnknownError("Exception key: not-handled"))
+
+    /// From Status Codes
+
+    convertToEs(Status.UNAVAILABLE.asRuntimeException()) should beSome(ServerUnavailable("UNAVAILABLE"))
+
   }
 }


### PR DESCRIPTION
 - define subscribe method that keeps track of pointer and
   re-subscribes after connectivity to ES is lost. Moreover,
   the method de-duplicates seens events by keeping track of
   previous positions of events by way of `changesBy` from
   `Stream`.

 - add `ServerUnavailable` and `UnknownError` exceptions.