### PR TITLE
core: tests + cleanups

### DIFF
--- a/core/src/main/scala/sec/api/mapping/implicits.scala
+++ b/core/src/main/scala/sec/api/mapping/implicits.scala
@@ -23,8 +23,4 @@ private[sec] object implicits {
       o.toRight(ProtoResultError(s"Required value $value missing or invalid.")).liftTo[F]
   }
 
-  implicit final class AttemptOps[T](inner: Attempt[T]) {
-    def unsafe: T = inner.leftMap(require(false, _)).toOption.get
-  }
-
 }

--- a/core/src/main/scala/sec/core/id.scala
+++ b/core/src/main/scala/sec/core/id.scala
@@ -27,11 +27,8 @@ object StreamId {
   def apply[F[_]](name: String)(implicit F: ApplicativeError[F, Throwable]): F[Id] =
     from(name).leftMap(StreamIdError).liftTo[F]
 
-  def from(name: String): Attempt[Id] = {
-    guardNonEmptyName(name) >>= guardNotStartsWith(metadataPrefix) >>= { n =>
-      if (n.startsWith(systemPrefix)) system(n.substring(systemPrefixLength)) else normal(n)
-    }
-  }
+  def from(name: String): Attempt[Id] =
+    guardNonEmptyName(name) >>= guardNotStartsWith(metadataPrefix) >>= stringToId
 
   final case class StreamIdError(msg: String) extends RuntimeException(msg)
 
@@ -82,7 +79,7 @@ object StreamId {
   private[sec] final val metadataPrefix: String    = "$$"
   private[sec] final val metadataPrefixLength: Int = metadataPrefix.length
 
-  private object systemStreams {
+  private[sec] object systemStreams {
     final val All: String       = "$all"
     final val Settings: String  = "$settings"
     final val Stats: String     = "$stats"

--- a/core/src/main/scala/sec/package.scala
+++ b/core/src/main/scala/sec/package.scala
@@ -20,4 +20,8 @@ package object sec {
 
 //======================================================================================================================
 
+  private[sec] implicit final class AttemptOps[T](inner: Attempt[T]) {
+    def unsafe: T = inner.leftMap(require(false, _)).toOption.get
+  }
+
 }

--- a/core/src/test/scala/sec/api/grpc/package.scala
+++ b/core/src/test/scala/sec/api/grpc/package.scala
@@ -2,9 +2,9 @@ package sec
 package api
 package grpc
 
+import cats.implicits._
 import io.grpc.{Metadata, Status, StatusRuntimeException}
 import org.specs2._
-import cats.implicits._
 import sec.core._
 import constants.{Exceptions => ce}
 import grpc.{keys => k}

--- a/core/src/test/scala/sec/api/mapping/implicits.scala
+++ b/core/src/test/scala/sec/api/mapping/implicits.scala
@@ -18,12 +18,6 @@ class ImplicitsSpec extends mutable.Specification {
     Option(1).require[Either[Throwable, *]]("test") should beRight(1)
   }
 
-  "AttemptOps.unsafe" >> {
-    "oops".asLeft[Int].unsafe should throwA[IllegalArgumentException]("oops")
-
-    1.asRight[String].unsafe shouldEqual 1
-  }
-
   "ByteVectorOps.toByteString" >> {
     ByteVector.encodeUtf8("abc").map(_.toByteString) should beRight(ByteString.copyFromUtf8("abc"))
   }

--- a/core/src/test/scala/sec/core/filter.scala
+++ b/core/src/test/scala/sec/core/filter.scala
@@ -1,0 +1,30 @@
+package sec
+package core
+
+import scala.util.matching.Regex
+import cats.data.NonEmptyList
+import cats.implicits._
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import EventFilter._
+
+class EventFilterSpec extends Specification with ScalaCheck {
+
+  "EventFilter" >> {
+
+    implicit val arbKind  = Arbitrary(Gen.oneOf[Kind](ByStreamId, ByEventType))
+    implicit val arbMax   = Arbitrary(Gen.posNum[Int])
+    implicit val arbRegex = Arbitrary(Gen.oneOf("^ctx1__.*".r, "^[^$].*".r))
+
+    "prefix" >> prop { (k: Kind, msw: Option[Int], fst: String, rest: List[String]) =>
+      prefix(k, msw, fst, rest: _*) shouldEqual
+        EventFilter(k, msw, NonEmptyList(PrefixFilter(fst), rest.map(PrefixFilter)).asLeft)
+    }
+
+    "regex" >> prop { (k: Kind, msw: Option[Int], filter: Regex) =>
+      regex(k, msw, filter.pattern.toString) shouldEqual EventFilter(k, msw, RegexFilter(filter).asRight)
+    }
+
+  }
+}

--- a/core/src/test/scala/sec/core/id.scala
+++ b/core/src/test/scala/sec/core/id.scala
@@ -1,0 +1,97 @@
+package sec
+package core
+
+import cats.implicits._
+import org.scalacheck._
+import cats.kernel.laws.discipline._
+import org.specs2.mutable.Specification
+import org.typelevel.discipline.specs2.mutable.Discipline
+import Arbitraries._
+
+class StreamIdSpec extends Specification with Discipline {
+
+  import StreamId.{systemStreams => ss}
+
+  type ErrorOr[A] = Either[Throwable, A]
+
+  "from" >> {
+    StreamId.from("") should beLeft("name cannot be empty")
+    StreamId.from("$$meta") should beLeft("value must not start with $$, but is $$meta")
+    StreamId.from("$users") shouldEqual StreamId.system("users")
+    StreamId.from("users") shouldEqual StreamId.normal("users")
+    StreamId.from(ss.All) shouldEqual StreamId.All.asRight
+    StreamId.from(ss.Settings) shouldEqual StreamId.Settings.asRight
+    StreamId.from(ss.Stats) shouldEqual StreamId.Stats.asRight
+    StreamId.from(ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
+    StreamId.from(ss.Streams) shouldEqual StreamId.Streams.asRight
+  }
+
+  "apply" >> {
+    StreamId[ErrorOr]("") should beLeft(StreamId.StreamIdError("name cannot be empty"))
+    StreamId[ErrorOr]("$$m") should beLeft(StreamId.StreamIdError("value must not start with $$, but is $$m"))
+    StreamId[ErrorOr]("$users") shouldEqual StreamId.system("users")
+    StreamId[ErrorOr]("users") shouldEqual StreamId.normal("users")
+    StreamId[ErrorOr](ss.All) shouldEqual StreamId.All.asRight
+    StreamId[ErrorOr](ss.Settings) shouldEqual StreamId.Settings.asRight
+    StreamId[ErrorOr](ss.Stats) shouldEqual StreamId.Stats.asRight
+    StreamId[ErrorOr](ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
+    StreamId[ErrorOr](ss.Streams) shouldEqual StreamId.Streams.asRight
+  }
+
+  "streamIdToString" >> {
+
+    val normalId = StreamId.normal("normal").unsafe
+    val systemId = StreamId.system("system").unsafe
+
+    StreamId.streamIdToString(StreamId.All) shouldEqual ss.All
+    StreamId.streamIdToString(StreamId.Settings) shouldEqual ss.Settings
+    StreamId.streamIdToString(StreamId.Stats) shouldEqual ss.Stats
+    StreamId.streamIdToString(StreamId.Scavenges) shouldEqual ss.Scavenges
+    StreamId.streamIdToString(StreamId.Streams) shouldEqual ss.Streams
+    StreamId.streamIdToString(systemId) shouldEqual "$system"
+    StreamId.streamIdToString(normalId) shouldEqual "normal"
+    StreamId.streamIdToString(systemId.meta) shouldEqual "$$$system"
+    StreamId.streamIdToString(normalId.meta) shouldEqual "$$normal"
+  }
+
+  "stringToStreamId" >> {
+
+    val normalId = StreamId.normal("normal").unsafe
+    val systemId = StreamId.system("system").unsafe
+
+    StreamId.stringToStreamId("$$normal") shouldEqual normalId.meta.asRight
+    StreamId.stringToStreamId("$$$system") shouldEqual systemId.meta.asRight
+    StreamId.stringToStreamId(ss.All) shouldEqual StreamId.All.asRight
+    StreamId.stringToStreamId(ss.Settings) shouldEqual StreamId.Settings.asRight
+    StreamId.stringToStreamId(ss.Stats) shouldEqual StreamId.Stats.asRight
+    StreamId.stringToStreamId(ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
+    StreamId.stringToStreamId(ss.Streams) shouldEqual StreamId.Streams.asRight
+    StreamId.stringToStreamId(systemId.stringValue) should beRight(systemId)
+    StreamId.stringToStreamId(normalId.stringValue) should beRight(normalId)
+  }
+
+  "show" >> {
+    val sid = sampleOf[StreamId]
+    sid.show shouldEqual sid.stringValue
+  }
+
+  "StreamIdOps" >> {
+    "stringValue" >> {
+      val sid = sampleOf[StreamId]
+      sid.stringValue shouldEqual StreamId.streamIdToString(sid)
+    }
+  }
+
+  "IdOps" >> {
+    "meta" >> {
+      val id = sampleOf[StreamId.Id]
+      id.meta shouldEqual StreamId.MetaId(id)
+    }
+  }
+
+  "Eq" >> {
+    implicit val cogen: Cogen[StreamId] = Cogen[String].contramap[StreamId](_.show)
+    checkAll("StreamId", EqTests[StreamId].eqv)
+  }
+
+}

--- a/core/src/test/scala/sec/core/version.scala
+++ b/core/src/test/scala/sec/core/version.scala
@@ -24,9 +24,7 @@ class VersionSpec extends Specification with Discipline {
     }
 
     "Eq" >> {
-      implicit val cogen: Cogen[StreamRevision] =
-        Cogen[String].contramap[StreamRevision](_.show)
-
+      implicit val cogen: Cogen[StreamRevision] = Cogen[String].contramap[StreamRevision](_.show)
       checkAll("StreamRevision", EqTests[StreamRevision].eqv)
     }
   }
@@ -50,9 +48,7 @@ class VersionSpec extends Specification with Discipline {
     }
 
     "Order" >> {
-      implicit val cogen: Cogen[EventNumber] =
-        Cogen[String].contramap[EventNumber](_.show)
-
+      implicit val cogen: Cogen[EventNumber] = Cogen[String].contramap[EventNumber](_.show)
       checkAll("EventNumber", OrderTests[EventNumber].order)
     }
   }
@@ -83,9 +79,7 @@ class VersionSpec extends Specification with Discipline {
     }
 
     "Order" >> {
-      implicit val cogen: Cogen[Position] =
-        Cogen[String].contramap[Position](_.show)
-
+      implicit val cogen: Cogen[Position] = Cogen[String].contramap[Position](_.show)
       checkAll("Position", OrderTests[Position].order)
     }
   }

--- a/core/src/test/scala/sec/package.scala
+++ b/core/src/test/scala/sec/package.scala
@@ -1,0 +1,33 @@
+package sec
+
+import cats.implicits._
+import org.specs2.mutable.Specification
+
+class SecPackageSpec extends Specification {
+
+  "AttemptOps" >> {
+    "unsafe" >> {
+      "oops".asLeft[Int].unsafe should throwA[IllegalArgumentException]("oops")
+      1.asRight[String].unsafe shouldEqual 1
+    }
+  }
+
+  "BooleanOps" >> {
+    "fold" >> {
+      true.fold("t", "f") shouldEqual "t"
+      false.fold("t", "f") shouldEqual "f"
+    }
+  }
+
+  "guardNonEmpty" >> {
+    guardNonEmpty("x")(null) should beLeft("x cannot be empty")
+    guardNonEmpty("x")("") should beLeft("x cannot be empty")
+    guardNonEmpty("x")("wohoo") should beRight("wohoo")
+  }
+
+  "guardNotStartsWith" >> {
+    guardNotStartsWith("$")("$") should beLeft("value must not start with $, but is $")
+    guardNotStartsWith("$")("a$") should beRight("a$")
+  }
+
+}


### PR DESCRIPTION
 - tests for `StreamId` & `EventFilter`
 - move `unsafe` to sec package object.