### PR TITLE
core: tests for event.scala types

### DIFF
--- a/core/src/main/scala/sec/core/event.scala
+++ b/core/src/main/scala/sec/core/event.scala
@@ -44,18 +44,6 @@ final case class EventRecord(
 
 object EventRecord {
 
-  implicit final class EventRecordOps(val e: EventRecord) extends AnyVal {
-
-    def createLink(eventId: UUID): Attempt[EventData] =
-      Either.cond(e.eventData.eventType != EventType.LinkTo, (), "Linking to a link is not supported.") >> {
-        Content.binary(s"${e.number.value}@${e.streamId.stringValue}") >>= { data =>
-          EventData(EventType.LinkTo, eventId, data, Content.BinaryEmpty)
-        }
-      }
-  }
-
-  ///
-
   implicit val showForEventRecord: Show[EventRecord] = Show.show[EventRecord] { er =>
     s"""
        |EventRecord(
@@ -220,7 +208,7 @@ object Content {
       }
 
       def isJson: Boolean   = tpe.fold(false, true)
-      def isBinary: Boolean = tpe.fold(true, false)
+      def isBinary: Boolean = !isJson
     }
 
     implicit val showForType: Show[Type] = Show.show[Type] {
@@ -244,7 +232,7 @@ object Content {
 
   ///
 
-  implicit val showByteVector: Show[ByteVector] = Show.show[ByteVector] { bv =>
+  private[sec] implicit val showByteVector: Show[ByteVector] = Show.show[ByteVector] { bv =>
     if (bv.isEmpty) s"empty"
     else if (bv.size < 32) s"${bv.size} bytes, 0x${bv.toHex}"
     else s"${bv.size} bytes, #${bv.hashCode}"

--- a/core/src/test/scala/sec/core/event.scala
+++ b/core/src/test/scala/sec/core/event.scala
@@ -1,0 +1,256 @@
+package sec
+package core
+
+import java.{util => ju}
+import java.time.ZonedDateTime
+import cats.implicits._
+import scodec.bits.ByteVector
+import org.specs2.mutable.Specification
+import Arbitraries._
+
+//======================================================================================================================
+
+class EventSpec extends Specification {
+
+  val er = EventRecord(
+    StreamId.from("abc-1234").unsafe,
+    EventNumber.exact(5L),
+    sampleOf[Position.Exact],
+    EventData("et", sampleOf[ju.UUID], Content.binary("abc").unsafe).unsafe,
+    sampleOf[ZonedDateTime]
+  )
+
+  val link = EventRecord(
+    StreamId.system("ce-abc").unsafe,
+    EventNumber.exact(10L),
+    Position.exact(1337L, 1337L),
+    EventData(EventType.LinkTo, sampleOf[ju.UUID], Content.binary("5@abc-1234").unsafe).unsafe,
+    sampleOf[ZonedDateTime]
+  )
+
+  val re = ResolvedEvent(er, link)
+
+  ///
+
+  "EventOps" >> {
+
+    "fold" >> {
+      er.fold(_ => "er", _ => "re") shouldEqual "er"
+      re.fold(_ => "er", _ => "re") shouldEqual "re"
+    }
+
+    "streamId" >> {
+      (er: Event).streamId shouldEqual er.streamId
+      (re: Event).streamId shouldEqual er.streamId
+    }
+
+    "number" >> {
+      (er: Event).number shouldEqual er.number
+      (re: Event).number shouldEqual er.number
+    }
+
+    "position" >> {
+      (er: Event).position shouldEqual er.position
+      (re: Event).position shouldEqual er.position
+    }
+
+    "eventData" >> {
+      (er: Event).eventData shouldEqual er.eventData
+      (re: Event).eventData shouldEqual er.eventData
+    }
+
+    "record" >> {
+      (er: Event).record shouldEqual er
+      (re: Event).record shouldEqual link
+    }
+
+    "created" >> {
+      (er: Event).created shouldEqual er.created
+      (re: Event).created shouldEqual er.created
+    }
+
+  }
+
+  "show" >> {
+
+    er.show shouldEqual (
+      s"""
+        |EventRecord(
+        |  streamId = ${er.streamId.show}, 
+        |  number   = ${er.number.show},
+        |  position = ${er.position.show},
+        |  data     = ${er.eventData.data.show}, 
+        |  metadata = ${er.eventData.metadata.show}, 
+        |  created  = ${er.created}
+        |)
+        |""".stripMargin
+    )
+
+    re.show shouldEqual (
+      s"""
+        |ResolvedEvent(
+        |  event = ${re.event.show},
+        |  link  = ${re.link.show}
+        |)
+        |""".stripMargin
+    )
+
+  }
+
+}
+
+//======================================================================================================================
+
+class EventTypeSpec extends Specification {
+
+  import EventType.{systemTypes => st}
+
+  val usr: EventType = EventType.userDefined("user").unsafe
+  val sys: EventType = EventType.systemDefined("system").unsafe
+
+  "apply" >> {
+    EventType("") should beLeft("Event type name cannot be empty")
+    EventType("$users") should beLeft("value must not start with $, but is $users")
+    EventType("users") should beRight(EventType.userDefined("users").unsafe)
+  }
+
+  "eventTypeToString" >> {
+    EventType.eventTypeToString(EventType.StreamDeleted) shouldEqual st.StreamDeleted
+    EventType.eventTypeToString(EventType.StatsCollected) shouldEqual st.StatsCollected
+    EventType.eventTypeToString(EventType.LinkTo) shouldEqual st.LinkTo
+    EventType.eventTypeToString(EventType.StreamReference) shouldEqual st.StreamReference
+    EventType.eventTypeToString(EventType.StreamMetadata) shouldEqual st.StreamMetadata
+    EventType.eventTypeToString(EventType.Settings) shouldEqual st.Settings
+    EventType.eventTypeToString(usr) shouldEqual "user"
+    EventType.eventTypeToString(sys) shouldEqual "$system"
+  }
+
+  "stringToEventType" >> {
+    EventType.stringToEventType(st.StreamDeleted) shouldEqual EventType.StreamDeleted.asRight
+    EventType.stringToEventType(st.StatsCollected) shouldEqual EventType.StatsCollected.asRight
+    EventType.stringToEventType(st.LinkTo) shouldEqual EventType.LinkTo.asRight
+    EventType.stringToEventType(st.StreamReference) shouldEqual EventType.StreamReference.asRight
+    EventType.stringToEventType(st.StreamMetadata) shouldEqual EventType.StreamMetadata.asRight
+    EventType.stringToEventType(st.Settings) shouldEqual EventType.Settings.asRight
+    EventType.stringToEventType(EventType.eventTypeToString(usr)) should beRight(usr)
+    EventType.stringToEventType(EventType.eventTypeToString(sys)) should beRight(sys)
+  }
+
+  "show" >> {
+    val et = sampleOf[EventType]
+    et.show shouldEqual EventType.eventTypeToString(et)
+  }
+
+}
+
+//======================================================================================================================
+
+class EventDataSpec extends Specification {
+
+  import Content.Type.{Binary => Bin, Json}
+
+  val bve = ByteVector.empty
+  val et  = EventType("eventType").unsafe
+  val id  = sampleOf[ju.UUID]
+
+  val dataJson   = Content.json("""{ "data": "1" }""").unsafe
+  val metaJson   = Content.json("""{ "meta": "2" }""").unsafe
+  val dataBinary = Content.binary("data").unsafe
+  val metaBinary = Content.binary("meta").unsafe
+
+  "apply" >> {
+
+    val errEmpty   = "Event type name cannot be empty"
+    val errStart   = "value must not start with $, but is $system"
+    val errContent = "Different content types for data & metadata is not supported."
+
+    def testCommon(data: Content, meta: Content) = {
+
+      val empty = Content.empty(data.contentType)
+
+      EventData("", id, data) should beLeft(errEmpty)
+      EventData("", id, data, meta) should beLeft(errEmpty)
+      EventData("$system", id, data) should beLeft(errStart)
+      EventData("$system", id, data, meta) should beLeft(errStart)
+      EventData(et, id, data) should beLike { case Right(EventData(`et`, `id`, `data`, `empty`))      => ok }
+      EventData(et, id, data, meta) should beLike { case Right(EventData(`et`, `id`, `data`, `meta`)) => ok }
+    }
+
+    ///
+
+    testCommon(dataJson, metaJson)
+    testCommon(dataBinary, metaBinary)
+
+    EventData(et, id, dataBinary, metaJson) should beLeft(errContent)
+    EventData(et, id, dataJson, metaBinary) should beLeft(errContent)
+
+    EventData.json(et, id, bve, bve).map(e => (e.data.contentType, e.metadata.contentType)) should beRight((Json, Json))
+    EventData.binary(et, id, bve, bve).map(e => (e.data.contentType, e.metadata.contentType)) should beRight((Bin, Bin))
+  }
+
+  "EventDataOps" >> {
+    "isJson" >> {
+      EventData(et, id, dataJson).map(_.isJson) should beRight(true)
+      EventData(et, id, dataBinary).map(_.isJson) should beRight(false)
+    }
+  }
+
+}
+
+//======================================================================================================================
+
+class ContentSpec extends Specification {
+
+  import Content.Type.{Binary, Json}
+
+  "apply" >> {
+    Content("\uD800", Binary) should beLeft("Input length = 1")
+    Content("\uD800", Json) should beLeft("Input length = 1")
+    Content("", Binary) should beRight(Content.BinaryEmpty)
+    Content("", Json) should beRight(Content.JsonEmpty)
+  }
+
+  "binary" >> {
+    Content.binary("1@a") shouldEqual Content("1@a", Binary)
+  }
+
+  "json" >> {
+    Content.json("""{ "link" : "1@a" }""") shouldEqual Content("""{ "link" : "1@a" }""", Json)
+  }
+
+  "show" >> {
+    Content.JsonEmpty.show shouldEqual ("Json(empty)")
+    Content.BinaryEmpty.show shouldEqual ("Binary(empty)")
+    Content.json("""{ "link" : "1@a" }""").unsafe.show shouldEqual """{ "link" : "1@a" }"""
+    Content.binary("a").unsafe.show shouldEqual "Binary(1 bytes, 0x61)"
+    Content.binary("a" * 31).unsafe.show shouldEqual (s"Binary(31 bytes, 0x${"61" * 31})")
+    Content.binary("a" * 32).unsafe.show shouldEqual "Binary(32 bytes, #-547736941)"
+  }
+
+  "Type" >> {
+    "show" >> {
+      (Binary: Content.Type).show shouldEqual "Binary"
+      (Json: Content.Type).show shouldEqual "Json"
+    }
+  }
+
+  "TypeOps" >> {
+    "fold" >> {
+      Binary.fold("b", "j") shouldEqual "b"
+      Json.fold("b", "j") shouldEqual "j"
+    }
+
+    "isJson" >> {
+      Json.isJson should beTrue
+      Binary.isJson should beFalse
+    }
+
+    "isBinary" >> {
+      Binary.isBinary should beTrue
+      Json.isBinary should beFalse
+    }
+  }
+
+}
+
+//======================================================================================================================

--- a/core/src/test/scala/sec/core/id.scala
+++ b/core/src/test/scala/sec/core/id.scala
@@ -14,6 +14,9 @@ class StreamIdSpec extends Specification with Discipline {
 
   type ErrorOr[A] = Either[Throwable, A]
 
+  val normalId = StreamId.normal("normal").unsafe
+  val systemId = StreamId.system("system").unsafe
+
   "from" >> {
     StreamId.from("") should beLeft("name cannot be empty")
     StreamId.from("$$meta") should beLeft("value must not start with $$, but is $$meta")
@@ -39,10 +42,6 @@ class StreamIdSpec extends Specification with Discipline {
   }
 
   "streamIdToString" >> {
-
-    val normalId = StreamId.normal("normal").unsafe
-    val systemId = StreamId.system("system").unsafe
-
     StreamId.streamIdToString(StreamId.All) shouldEqual ss.All
     StreamId.streamIdToString(StreamId.Settings) shouldEqual ss.Settings
     StreamId.streamIdToString(StreamId.Stats) shouldEqual ss.Stats
@@ -55,10 +54,6 @@ class StreamIdSpec extends Specification with Discipline {
   }
 
   "stringToStreamId" >> {
-
-    val normalId = StreamId.normal("normal").unsafe
-    val systemId = StreamId.system("system").unsafe
-
     StreamId.stringToStreamId("$$normal") shouldEqual normalId.meta.asRight
     StreamId.stringToStreamId("$$$system") shouldEqual systemId.meta.asRight
     StreamId.stringToStreamId(ss.All) shouldEqual StreamId.All.asRight


### PR DESCRIPTION
 - add tests for types in event.scala
 - remove `createLink` as it is probably not something people need.
 - add more arbitrary instances