### PR TITLE
core: upstream adjustments

### DIFF
--- a/core/src/main/protobuf/persistent.proto
+++ b/core/src/main/protobuf/persistent.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package event_store.client.persistent_subscriptions;
 option java_package = "com.eventstore.client.persistentsubscriptions";
 
+import "shared.proto";
+
 service PersistentSubscriptions {
 	rpc Create (CreateReq) returns (CreateResp);
 	rpc Update (UpdateReq) returns (UpdateResp);
@@ -24,23 +26,23 @@ message ReadReq {
 
 		message UUIDOption {
 			oneof content {
-				Empty structured = 1;
-				Empty string = 2;
+				event_store.client.shared.Empty structured = 1;
+				event_store.client.shared.Empty string = 2;
 			}
 		}
 	}
 
 	message Ack {
 		bytes id = 1;
-		repeated UUID ids = 2;
+		repeated event_store.client.shared.UUID ids = 2;
 	}
 
 	message Nack {
 		bytes id = 1;
-		repeated UUID ids = 2;
+		repeated event_store.client.shared.UUID ids = 2;
 		Action action = 3;
 		string reason = 4;
-		
+
 		enum Action {
 			Unknown = 0;
 			Park = 1;
@@ -49,30 +51,26 @@ message ReadReq {
 			Stop = 4;
 		}
 	}
-
-	message Empty {
-
-	}
 }
 
 message ReadResp {
 	oneof content {
 		ReadEvent event = 1;
-		Empty empty = 2;
+		SubscriptionConfirmation subscription_confirmation = 2;
 	}
 	message ReadEvent {
 		RecordedEvent event = 1;
 		RecordedEvent link = 2;
 		oneof position {
 			uint64 commit_position = 3;
-			Empty no_position = 4;
+			event_store.client.shared.Empty no_position = 4;
 		}
 		oneof count {
 			int32 retry_count = 5;
-			Empty empty = 6;			
+			event_store.client.shared.Empty no_retry_count = 6;
 		}
 		message RecordedEvent {
-			UUID id = 1;
+			event_store.client.shared.UUID id = 1;
 			string stream_name = 2;
 			uint64 stream_revision = 3;
 			uint64 prepare_position = 4;
@@ -82,7 +80,8 @@ message ReadResp {
 			bytes data = 8;
 		}
 	}
-	message Empty {
+	message SubscriptionConfirmation {
+		string subscription_id = 1;
 	}
 }
 
@@ -166,16 +165,4 @@ message DeleteReq {
 }
 
 message DeleteResp {
-}
-
-message UUID {
-	oneof value {
-		Structured structured = 1;
-		string string = 2;
-	}
-
-	message Structured {
-		int64 most_significant_bits = 1;
-		int64 least_significant_bits = 2;
-	}
 }

--- a/core/src/main/protobuf/projections.proto
+++ b/core/src/main/protobuf/projections.proto
@@ -3,6 +3,7 @@ package event_store.client.projections;
 option java_package = "com.eventstore.client.projections";
 
 import "google/protobuf/struct.proto";
+import "shared.proto";
 
 service Projections {
 	rpc Create (CreateReq) returns (CreateResp);
@@ -21,7 +22,7 @@ message CreateReq {
 
 	message Options {
 		oneof mode {
-			Empty one_time = 1;
+			event_store.client.shared.Empty one_time = 1;
 			Transient transient = 2;
 			Continuous continuous = 3;
 		}
@@ -34,8 +35,6 @@ message CreateReq {
 			string name = 1;
 			bool track_emitted_streams = 2;
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -50,10 +49,8 @@ message UpdateReq {
 		string query = 2;
 		oneof emit_option {
 			bool emit_enabled = 3;
-			Empty no_emit_options = 4;
+			event_store.client.shared.Empty no_emit_options = 4;
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -79,13 +76,11 @@ message StatisticsReq {
 	message Options {
 		oneof mode {
 			string name = 1;
-			Empty all = 2;
-			Empty transient = 3;
-			Empty continuous = 4;
-			Empty one_time = 5;
+			event_store.client.shared.Empty all = 2;
+			event_store.client.shared.Empty transient = 3;
+			event_store.client.shared.Empty continuous = 4;
+			event_store.client.shared.Empty one_time = 5;
 		}
-	}
-	message Empty {
 	}
 }
 

--- a/core/src/main/protobuf/shared.proto
+++ b/core/src/main/protobuf/shared.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+package event_store.client.shared;
+option java_package = "com.eventstore.client.shared";
+
+message UUID {
+	oneof value {
+		Structured structured = 1;
+		string string = 2;
+	}
+
+	message Structured {
+		int64 most_significant_bits = 1;
+		int64 least_significant_bits = 2;
+	}
+}
+message Empty {
+}

--- a/core/src/main/protobuf/streams.proto
+++ b/core/src/main/protobuf/streams.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package event_store.client.streams;
 option java_package = "com.eventstore.client.streams";
 
+import "shared.proto";
+
 service Streams {
 	rpc Read (ReadReq) returns (stream ReadResp);
 	rpc Append (stream AppendReq) returns (AppendResp);
@@ -25,7 +27,7 @@ message ReadReq {
 		}
 		oneof filter_option {
 			FilterOptions filter = 7;
-			Empty no_filter = 8;
+			event_store.client.shared.Empty no_filter = 8;
 		}
 		UUIDOption uuid_option = 9;
 
@@ -37,15 +39,15 @@ message ReadReq {
 			string stream_name = 1;
 			oneof revision_option {
 				uint64 revision = 2;
-				Empty start = 3;
-				Empty end = 4;
+				event_store.client.shared.Empty start = 3;
+				event_store.client.shared.Empty end = 4;
 			}
 		}
 		message AllOptions {
 			oneof all_option {
 				Position position = 1;
-				Empty start = 2;
-				Empty end = 3;
+				event_store.client.shared.Empty start = 2;
+				event_store.client.shared.Empty end = 3;
 			}
 		}
 		message SubscriptionOptions {
@@ -60,9 +62,10 @@ message ReadReq {
 				Expression event_type = 2;
 			}
 			oneof window {
-				int32 max = 3;
-				Empty count = 4;
+				uint32 max = 3;
+				event_store.client.shared.Empty count = 4;
 			}
+			uint32 checkpointIntervalMultiplier = 5;
 
 			message Expression {
 				string regex = 1;
@@ -71,13 +74,10 @@ message ReadReq {
 		}
 		message UUIDOption {
 			oneof content {
-				Empty structured = 1;
-				Empty string = 2;
+				event_store.client.shared.Empty structured = 1;
+				event_store.client.shared.Empty string = 2;
 			}
-
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -85,6 +85,7 @@ message ReadResp {
 	oneof content {
 		ReadEvent event = 1;
 		SubscriptionConfirmation confirmation = 2;
+		Checkpoint checkpoint = 3;
 	}
 
 	message ReadEvent {
@@ -92,11 +93,11 @@ message ReadResp {
 		RecordedEvent link = 2;
 		oneof position {
 			uint64 commit_position = 3;
-			Empty no_position = 4;
+			event_store.client.shared.Empty no_position = 4;
 		}
 
 		message RecordedEvent {
-			UUID id = 1;
+			event_store.client.shared.UUID id = 1;
 			string stream_name = 2;
 			uint64 stream_revision = 3;
 			uint64 prepare_position = 4;
@@ -109,7 +110,9 @@ message ReadResp {
 	message SubscriptionConfirmation {
 		string subscription_id = 1;
 	}
-	message Empty {
+	message Checkpoint {
+		uint64 commit_position = 1;
+		uint64 prepare_position = 2;
 	}
 }
 
@@ -123,37 +126,32 @@ message AppendReq {
 		string stream_name = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			Empty no_stream = 3;
-			Empty any = 4;
-			Empty stream_exists = 5;
+			event_store.client.shared.Empty no_stream = 3;
+			event_store.client.shared.Empty any = 4;
+			event_store.client.shared.Empty stream_exists = 5;
 		}
 	}
 	message ProposedMessage {
-		UUID id = 1;
+		event_store.client.shared.UUID id = 1;
 		map<string, string> metadata = 2;
 		bytes custom_metadata = 3;
 		bytes data = 4;
 	}
-	message Empty {
-	}
-
 }
 
 message AppendResp {
 	oneof current_revision_option {
 		uint64 current_revision = 1;
-		Empty no_stream = 2;
+		event_store.client.shared.Empty no_stream = 2;
 	}
 	oneof position_option {
 		Position position = 3;
-		Empty empty = 4;
+		event_store.client.shared.Empty no_position = 4;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
-	}
-	message Empty {
 	}
 }
 
@@ -164,26 +162,22 @@ message DeleteReq {
 		string stream_name = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			Empty no_stream = 3;
-			Empty any = 4;
-			Empty stream_exists = 5;
+			event_store.client.shared.Empty no_stream = 3;
+			event_store.client.shared.Empty any = 4;
+			event_store.client.shared.Empty stream_exists = 5;
 		}
-	}
-	message Empty {
 	}
 }
 
 message DeleteResp {
 	oneof position_option {
 		Position position = 1;
-		Empty empty = 2;
+		event_store.client.shared.Empty no_position = 2;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
-	}
-	message Empty {
 	}
 }
 
@@ -194,37 +188,21 @@ message TombstoneReq {
 		string stream_name = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			Empty no_stream = 3;
-			Empty any = 4;
-			Empty stream_exists = 5;
+			event_store.client.shared.Empty no_stream = 3;
+			event_store.client.shared.Empty any = 4;
+			event_store.client.shared.Empty stream_exists = 5;
 		}
-	}
-	message Empty {
 	}
 }
 
 message TombstoneResp {
 	oneof position_option {
 		Position position = 1;
-		Empty empty = 2;
+		event_store.client.shared.Empty no_position = 2;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
-	}
-	message Empty {
-	}
-}
-
-message UUID {
-	oneof value {
-		Structured structured = 1;
-		string string = 2;
-	}
-
-	message Structured {
-		int64 most_significant_bits = 1;
-		int64 least_significant_bits = 2;
 	}
 }

--- a/core/src/main/protobuf/users.proto
+++ b/core/src/main/protobuf/users.proto
@@ -93,8 +93,6 @@ message DetailsResp {
 			int64 ticks_since_epoch = 1;
 		}
 	}
-	message Empty {
-	}
 }
 
 message ChangePasswordReq {

--- a/core/src/main/scala/sec/api/filter.scala
+++ b/core/src/main/scala/sec/api/filter.scala
@@ -1,5 +1,5 @@
 package sec
-package core
+package api
 
 import scala.util.matching.Regex
 import cats.implicits._

--- a/core/src/main/scala/sec/api/grpc/constants.scala
+++ b/core/src/main/scala/sec/api/grpc/constants.scala
@@ -14,7 +14,8 @@ private[api] object constants {
     val StreamDeleted: String                      = "stream-deleted"
     val WrongExpectedVersion: String               = "wrong-expected-version"
     val StreamNotFound: String                     = "stream-not-found"
-    val MaximumAppendSizeExceeded: String          = "max-append-size-exceeded"
+    val MaximumAppendSizeExceeded: String          = "maximum-append-size-exceeded"
+    val NotLeader: String                          = "not-leader"
     val PersistentSubscriptionFailed: String       = "persistent-subscription-failed"
     val PersistentSubscriptionDoesNotExist: String = "persistent-subscription-does-not-exist"
     val PersistentSubscriptionExists: String       = "persistent-subscription-exists"
@@ -22,13 +23,16 @@ private[api] object constants {
     val PersistentSubscriptionDropped: String      = "persistent-subscription-dropped"
     val UserNotFound: String                       = "user-not-found"
     val UserConflict: String                       = "user-conflict"
+    val ScavengeNotFound: String                   = "scavenge-not-found"
 
     val ExpectedVersion: String   = "expected-version"
     val ActualVersion: String     = "actual-version"
-    val MaximumAppendSize: String = "maximum-append-size"
     val StreamName: String        = "stream-name"
     val GroupName: String         = "group-name"
     val Reason: String            = "reason"
+    val MaximumAppendSize: String = "maximum-append-size"
+    val ScavengeId: String        = "scavenge-id"
+    val LeaderEndpoint: String    = "leader-endpoint"
 
     val LoginName = "login-name"
   }
@@ -36,9 +40,16 @@ private[api] object constants {
 //======================================================================================================================
 
   object Metadata {
-    val IsJson: String  = "is-json"
-    val Type: String    = "type"
-    val Created: String = "created"
+
+    val ContentType: String = "content-type"
+    val Type: String        = "type"
+    val Created: String     = "created"
+
+    object ContentTypes {
+      val ApplicationJson: String        = "application/json"
+      val ApplicationOctetStream: String = "application/octet-stream"
+    }
+
   }
 
 //======================================================================================================================
@@ -47,6 +58,7 @@ private[api] object constants {
     val Authorization: String  = "authorization"
     val BasicScheme: String    = "Basic"
     val ConnectionName: String = "connection-name"
+    val RequiresLeader: String = "requires-leader"
   }
 
 //======================================================================================================================

--- a/core/src/main/scala/sec/api/mapping/shared.scala
+++ b/core/src/main/scala/sec/api/mapping/shared.scala
@@ -1,0 +1,25 @@
+package sec
+package api
+package mapping
+
+import java.util.{UUID => JUUID}
+import cats.implicits._
+import com.eventstore.client.shared.UUID
+
+object shared {
+
+  val mkUuid: JUUID => UUID = j =>
+    UUID().withStructured(UUID.Structured(j.getMostSignificantBits(), j.getLeastSignificantBits()))
+
+  def mkJuuid[F[_]: ErrorA](uuid: UUID): F[JUUID] = {
+
+    val juuid = uuid.value match {
+      case UUID.Value.Structured(v) => new JUUID(v.mostSignificantBits, v.leastSignificantBits).asRight
+      case UUID.Value.String(v)     => Either.catchNonFatal(JUUID.fromString(v)).leftMap(_.getMessage())
+      case UUID.Value.Empty         => "UUID is missing".asLeft
+    }
+
+    juuid.leftMap(ProtoResultError).liftTo[F]
+  }
+
+}

--- a/core/src/main/scala/sec/core/event.scala
+++ b/core/src/main/scala/sec/core/event.scala
@@ -187,7 +187,7 @@ object EventData {
   ///
 
   implicit class EventDataOps(ed: EventData) {
-    def isJson: Boolean = ed.data.contentType.isJson
+    def contentType: Content.Type = ed.data.contentType
   }
 
 }

--- a/core/src/main/scala/sec/syntax/streams.scala
+++ b/core/src/main/scala/sec/syntax/streams.scala
@@ -3,7 +3,7 @@ package syntax
 
 import cats.data.NonEmptyList
 import fs2.Stream
-import sec.core.{Event, EventData, EventFilter, EventNumber, Position, StreamId, StreamRevision}
+import sec.core._
 import sec.api._
 
 final class StreamsSyntax[F[_]](val s: Streams[F]) extends AnyVal {
@@ -13,19 +13,25 @@ final class StreamsSyntax[F[_]](val s: Streams[F]) extends AnyVal {
   def subscribeToAll(
     exclusiveFrom: Option[Position],
     resolveLinkTos: Boolean = false,
-    filter: Option[EventFilter] = None,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.subscribeToAll(exclusiveFrom, resolveLinkTos, filter, credentials)
+    s.subscribeToAll(exclusiveFrom, resolveLinkTos, credentials)
+
+  def subscribeToAllFiltered(
+    exclusiveFrom: Option[Position],
+    filter: EventFilter,
+    resolveLinkTos: Boolean = false,
+    credentials: Option[UserCredentials] = None
+  ): Stream[F, Either[Position, Event]] =
+    s.subscribeToAll(exclusiveFrom, filter, resolveLinkTos, credentials)
 
   def subscribeToStream(
     streamId: StreamId,
     exclusiveFrom: Option[EventNumber],
     resolveLinkTos: Boolean = false,
-    failIfNotFound: Boolean = false,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos, failIfNotFound, credentials)
+    s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos, credentials)
 
   /// Read
 

--- a/core/src/test/scala/sec/api/filter.scala
+++ b/core/src/test/scala/sec/api/filter.scala
@@ -1,5 +1,5 @@
 package sec
-package core
+package api
 
 import scala.util.matching.Regex
 import cats.data.NonEmptyList

--- a/core/src/test/scala/sec/api/mapping/shared.scala
+++ b/core/src/test/scala/sec/api/mapping/shared.scala
@@ -1,0 +1,33 @@
+package sec
+package api
+package mapping
+
+import java.util.{UUID => JUUID}
+import cats.implicits._
+import org.specs2._
+import com.eventstore.client.shared._
+import sec.api.mapping.shared._
+
+class SharedMappingSpec extends mutable.Specification {
+
+  type ErrorOr[A] = Either[Throwable, A]
+
+  "shared" >> {
+
+    val uuidString     = "e5390fcb-48bd-4895-bcc3-01629cca2af6"
+    val juuid          = JUUID.fromString(uuidString)
+    val uuidStructured = UUID.Structured(juuid.getMostSignificantBits(), juuid.getLeastSignificantBits())
+
+    "mkJuuid" >> {
+      mkJuuid[ErrorOr](UUID().withValue(UUID.Value.Empty)) shouldEqual ProtoResultError("UUID is missing").asLeft
+      mkJuuid[ErrorOr](UUID().withString(uuidString)) shouldEqual juuid.asRight
+      mkJuuid[ErrorOr](UUID().withStructured(uuidStructured)) shouldEqual juuid.asRight
+    }
+
+    "mkUuid" >> {
+      mkUuid(juuid) shouldEqual UUID().withStructured(uuidStructured)
+    }
+
+  }
+
+}

--- a/core/src/test/scala/sec/api/streams.scala
+++ b/core/src/test/scala/sec/api/streams.scala
@@ -155,9 +155,7 @@ class StreamsITest extends ITest {
             .compile
             .toList
 
-          val setup = write >>= { wr =>
-            delete(wr.currentRevision).void >> verifyDeleted >> read
-          }
+          val setup = write >>= { wr => delete(wr.currentRevision).void >> verifyDeleted >> read }
 
           def verify(es: List[Event]) =
             es.lastOption.toRight(ValidationError("expected metadata")).liftTo[IO] >>= { ts =>

--- a/core/src/test/scala/sec/core/event.scala
+++ b/core/src/test/scala/sec/core/event.scala
@@ -196,9 +196,9 @@ class EventDataSpec extends Specification {
   }
 
   "EventDataOps" >> {
-    "isJson" >> {
-      EventData(et, id, dataJson).isJson should beTrue
-      EventData(et, id, dataBinary).isJson should beFalse
+    "contentType" >> {
+      EventData(et, id, dataJson).contentType shouldEqual Content.Type.Json
+      EventData(et, id, dataBinary).contentType shouldEqual Content.Type.Binary
     }
   }
 


### PR DESCRIPTION
 - sync proto defs from upstream.

 - change to use `ContentType` instead
   of `IsJson`

 - initial work of `subscribeToAll` with filter
   with regards to `Checkpoint`.

 - move `EventFilter` to api package.