### PR TITLE
api: remove filter from read all

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ val devScalacOptions = { options: Seq[String] =>
 
 inThisBuild(
   List(
-    scalaVersion := "2.13.1",
+    scalaVersion := "2.13.2",
     organization := "io.github.ahjohannessen",
     developers := List(
       Developer("ahjohannessen", "Alex Henning Johannessen", "ahjohannessen@gmail.com", url("https://github.com/ahjohannessen"))

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -138,8 +138,7 @@ private[sec] object streams {
       position: Position,
       direction: Direction,
       maxCount: Long,
-      resolveLinkTos: Boolean,
-      filter: Option[EventFilter]
+      resolveLinkTos: Boolean
     ): ReadReq = {
 
       val options = ReadReq
@@ -148,7 +147,7 @@ private[sec] object streams {
         .withCount(maxCount)
         .withReadDirection(mapDirection(direction))
         .withResolveLinks(resolveLinkTos)
-        .withFilterOption(mapReadEventFilter(filter))
+        .withNoFilter(empty)
         .withUuidOption(uuidOption)
 
       ReadReq().withOptions(options)

--- a/core/src/main/scala/sec/syntax/streams.scala
+++ b/core/src/main/scala/sec/syntax/streams.scala
@@ -57,19 +57,17 @@ final class StreamsSyntax[F[_]](val s: Streams[F]) extends AnyVal {
     position: Position,
     maxCount: Long,
     resolveLinkTos: Boolean = false,
-    filter: Option[EventFilter] = None,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.readAll(position, Direction.Forwards, maxCount, resolveLinkTos, filter, credentials)
+    s.readAll(position, Direction.Forwards, maxCount, resolveLinkTos, credentials)
 
   def readAllBackwards(
     position: Position,
     maxCount: Long,
     resolveLinkTos: Boolean = false,
-    filter: Option[EventFilter] = None,
     credentials: Option[UserCredentials] = None
   ): Stream[F, Event] =
-    s.readAll(position, Direction.Backwards, maxCount, resolveLinkTos, filter, credentials)
+    s.readAll(position, Direction.Backwards, maxCount, resolveLinkTos, credentials)
 
   /// Append
 

--- a/core/src/test/scala/sec/api/callcontext.scala
+++ b/core/src/test/scala/sec/api/callcontext.scala
@@ -1,7 +1,6 @@
 package sec
 package api
 
-import org.specs2._
 import org.specs2.mutable.Specification
 
 class UserCredentialsSpec extends Specification {

--- a/core/src/test/scala/sec/api/direction.scala
+++ b/core/src/test/scala/sec/api/direction.scala
@@ -1,7 +1,6 @@
 package sec
 package api
 
-import org.specs2._
 import cats.implicits._
 import cats.kernel.laws.discipline._
 import org.scalacheck._

--- a/core/src/test/scala/sec/api/mapping/streams.scala
+++ b/core/src/test/scala/sec/api/mapping/streams.scala
@@ -159,10 +159,8 @@ class StreamsMappingSpec extends mutable.Specification {
 
     "mkReadAllReq" >> {
 
-      import EventFilter._
-
-      def test(from: c.Position, rd: Direction, maxCount: Long, rlt: Boolean, filter: Option[EventFilter]) =
-        mkReadAllReq(from, rd, maxCount, rlt, filter) shouldEqual ReadReq().withOptions(
+      def test(from: c.Position, rd: Direction, maxCount: Long, rlt: Boolean) =
+        mkReadAllReq(from, rd, maxCount, rlt) shouldEqual ReadReq().withOptions(
           ReadReq
             .Options()
             .withAll(ReadReq.Options.AllOptions(mapPosition(from)))
@@ -170,7 +168,7 @@ class StreamsMappingSpec extends mutable.Specification {
             .withCount(maxCount)
             .withReadDirection(mapDirection(rd))
             .withResolveLinks(rlt)
-            .withFilterOption(mapReadEventFilter(filter))
+            .withNoFilter(empty)
             .withUuidOption(uuidOption)
         )
 
@@ -179,8 +177,7 @@ class StreamsMappingSpec extends mutable.Specification {
         rd <- List(Direction.Forwards, Direction.Backwards)
         mc <- List(100L, 1000L, 10000L)
         rt <- List(true, false)
-        fi <- List(Option.empty[EventFilter], prefix(ByStreamId, None, "abc").some)
-      } yield test(fr, rd, mc, rt, fi)
+      } yield test(fr, rd, mc, rt)
     }
 
     "mkSoftDeleteReq" >> {


### PR DESCRIPTION
 - remove `EventFilter` from `readAll` as it
   is considered unfinished upstream.