### PR TITLE
misc: various simplifications & cleanups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ lazy val root = project
   .settings(skip in publish := true)
   .aggregate(core, netty, demo)
 
-lazy val basePath  = file("").getAbsoluteFile.toPath
-lazy val certsPath = Seq[BuildInfoKey]("certsPath" -> basePath / "certs")
+lazy val basePath     = file("").getAbsoluteFile.toPath
+lazy val certsPathKey = "certsPath" -> basePath / "certs"
 
 lazy val IntegrationTest = config("it") extend Test
 
@@ -33,13 +33,14 @@ lazy val core = project
           specs2ScalaCheck,
           circeGeneric,
           grpcNetty,
+          tcnative,
           log4catsSlf4j,
           logback
         )
   )
   .settings(
     addBuildInfoToConfig(Test),
-    Test / buildInfoKeys := certsPath,
+    Test / buildInfoKeys := buildInfoKeys.value :+ BuildInfoKey(certsPathKey),
     Test / buildInfoObject := "TestBuildInfo"
   )
 
@@ -49,7 +50,7 @@ lazy val netty = project
   .settings(commonSettings)
   .settings(
     name := "sec",
-    libraryDependencies ++= compileM(grpcNetty)
+    libraryDependencies ++= compileM(grpcNetty, tcnative)
   )
 
 lazy val demo = project
@@ -57,7 +58,7 @@ lazy val demo = project
   .dependsOn(netty)
   .settings(
     name := "demo",
-    buildInfoKeys := certsPath,
+    buildInfoKeys := buildInfoKeys.value :+ BuildInfoKey(certsPathKey),
     buildInfoPackage := "sec.demo",
     libraryDependencies ++= compileM(log4catsSlf4j, logback),
     skip in publish := true
@@ -84,7 +85,7 @@ val devScalacOptions = { options: Seq[String] =>
 
 inThisBuild(
   List(
-    scalaVersion := "2.13.2",
+    scalaVersion := "2.13.3",
     organization := "io.github.ahjohannessen",
     developers := List(
       Developer(

--- a/core/src/main/scala/sec/api/cluster/settings.scala
+++ b/core/src/main/scala/sec/api/cluster/settings.scala
@@ -3,11 +3,14 @@ package api
 package cluster
 
 import scala.concurrent.duration._
+import cats.implicits._
+import retries._
 
 final private[sec] case class ClusterSettings(
   maxDiscoverAttempts: Option[Int],
   retryDelay: FiniteDuration,
-  retryStrategy: RetryStrategy,
+  retryMaxDelay: FiniteDuration,
+  retryBackoffFactor: Double,
   readTimeout: FiniteDuration,
   notificationInterval: FiniteDuration,
   preference: NodePreference
@@ -17,19 +20,31 @@ private[sec] object ClusterSettings {
 
   val default: ClusterSettings = ClusterSettings(
     maxDiscoverAttempts  = None,
-    retryDelay           = 200.millis,
-    retryStrategy        = RetryStrategy.Identity,
+    retryDelay           = 100.millis,
+    retryMaxDelay        = 2.seconds,
+    retryBackoffFactor   = 1.25,
     readTimeout          = 5.seconds,
     notificationInterval = 100.millis,
     preference           = NodePreference.Leader
   )
 
-  implicit final class SettingsOps(val s: ClusterSettings) extends AnyVal {
-    def withMaxDiscoverAttempts(max: Option[Int]): ClusterSettings          = s.copy(maxDiscoverAttempts = max)
-    def withRetryDelay(delay: FiniteDuration): ClusterSettings              = s.copy(retryDelay = delay)
-    def withReadTimeout(timeout: FiniteDuration): ClusterSettings           = s.copy(readTimeout = timeout)
-    def withNotificationInterval(interval: FiniteDuration): ClusterSettings = s.copy(notificationInterval = interval)
-    def withNodePreference(np: NodePreference): ClusterSettings             = s.copy(preference = np)
+  implicit final class ClusterSettingsOps(val cs: ClusterSettings) extends AnyVal {
+
+    def withMaxDiscoverAttempts(max: Option[Int]): ClusterSettings          = cs.copy(maxDiscoverAttempts = max)
+    def withRetryDelay(delay: FiniteDuration): ClusterSettings              = cs.copy(retryDelay = delay)
+    def withRetryMaxDelay(maxDelay: FiniteDuration): ClusterSettings        = cs.copy(retryMaxDelay = maxDelay)
+    def withRetryBackoffFactor(factor: Double): ClusterSettings             = cs.copy(retryBackoffFactor = factor)
+    def withReadTimeout(timeout: FiniteDuration): ClusterSettings           = cs.copy(readTimeout = timeout)
+    def withNotificationInterval(interval: FiniteDuration): ClusterSettings = cs.copy(notificationInterval = interval)
+    def withNodePreference(np: NodePreference): ClusterSettings             = cs.copy(preference = np)
+
+    def retryConfig: RetryConfig = RetryConfig(
+      cs.retryDelay,
+      cs.retryMaxDelay,
+      cs.retryBackoffFactor,
+      cs.maxDiscoverAttempts.getOrElse(Int.MaxValue),
+      cs.readTimeout.some
+    )
   }
 
 }

--- a/core/src/main/scala/sec/api/retries.scala
+++ b/core/src/main/scala/sec/api/retries.scala
@@ -1,0 +1,76 @@
+package sec
+package api
+
+import scala.util.control.NonFatal
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import cats.implicits._
+import cats.effect.{Concurrent, Timer}
+import cats.effect.implicits._
+import io.chrisdavenport.log4cats.Logger
+
+private[sec] object retries {
+
+  sealed abstract case class RetryConfig(
+    delay: FiniteDuration,
+    maxDelay: FiniteDuration,
+    backoffFactor: Double,
+    maxAttempts: Int,
+    timeout: Option[FiniteDuration]
+  )
+
+  object RetryConfig {
+
+    def apply(
+      delay: FiniteDuration,
+      maxDelay: FiniteDuration,
+      backoffFactor: Double,
+      maxAttempts: Int,
+      timeout: Option[FiniteDuration]
+    ): RetryConfig =
+      new RetryConfig(delay.min(maxDelay), maxDelay, backoffFactor.max(1), math.max(maxAttempts, 1), timeout) {}
+
+    implicit final class RetryConfigOps(val c: RetryConfig) extends AnyVal {
+
+      def nextDelay(d: FiniteDuration): FiniteDuration =
+        (d * c.backoffFactor).min(c.maxDelay) match {
+          case f: FiniteDuration    => f
+          case _: Duration.Infinite => c.maxDelay
+        }
+
+      def logWarn[F[_]](action: String, log: Logger[F])(attempt: Int, delay: FiniteDuration, th: Throwable): F[Unit] =
+        log.warn(
+          s"$action failed, attempt $attempt of ${c.maxAttempts}, retrying in ${format(delay)}. Details: ${th.getMessage}"
+        )
+
+      def logError[F[_]](action: String, log: Logger[F])(th: Throwable): F[Unit] =
+        log.error(s"$action failed after ${c.maxAttempts} attempts. Details: ${th.getMessage}")
+
+    }
+  }
+
+  // TODO: Tests
+  def retry[F[_]: Concurrent: Timer, A](
+    action: F[A],
+    actionName: String,
+    retryConfig: RetryConfig,
+    log: Logger[F]
+  )(retryOn: Throwable => Boolean): F[A] = {
+    import retryConfig._
+
+    val fa       = timeout.fold(action)(action.timeout)
+    val logWarn  = retryConfig.logWarn[F](actionName, log) _
+    val logError = retryConfig.logError[F](actionName, log) _
+
+    def run(attempts: Int, d: FiniteDuration): F[A] = fa.recoverWith {
+      case NonFatal(t) if retryOn(t) =>
+        val attempt = attempts + 1
+        if (attempt < retryConfig.maxAttempts)
+          logWarn(attempt, d, t) *> Timer[F].sleep(d) *> run(attempt, retryConfig.nextDelay(d))
+        else
+          logError(t) *> t.raiseError[F, A]
+    }
+
+    run(0, retryConfig.delay)
+  }
+
+}

--- a/core/src/main/scala/sec/client/client.scala
+++ b/core/src/main/scala/sec/client/client.scala
@@ -11,6 +11,7 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.noop.NoOpLogger
 import sec.core._
 import sec.api._
+import sec.api.cluster.ClusterSettings
 import sec.api.grpc.metadata._
 import sec.api.grpc.convert.convertToEs
 
@@ -22,10 +23,10 @@ trait EsClient[F[_]] {
 object EsClient {
 
   def single[F[_]: ConcurrentEffect: Timer](endpoint: Endpoint): SingleNodeBuilder[F] =
-    SingleNodeBuilder[F](endpoint, NoOpLogger.impl[F])
+    SingleNodeBuilder[F](endpoint, None, Options.default, NoOpLogger.impl[F])
 
   def cluster[F[_]: ConcurrentEffect: Timer](seed: NonEmptySet[Endpoint], authority: String): ClusterBuilder[F] =
-    ClusterBuilder[F](seed, authority, NoOpLogger.impl[F])
+    ClusterBuilder[F](seed, authority, Options.default, ClusterSettings.default, NoOpLogger.impl[F])
 
 //======================================================================================================================
 
@@ -60,7 +61,7 @@ object EsClient {
   }
 
   private[sec] def mkOpts[F[_]](oo: OperationOptions, log: Logger[F], prefix: String): Opts[F] =
-    Opts[F](oo, defaultRetryOn, log.withModifiedString(s => s"$prefix: $s"))
+    Opts[F](oo.retryEnabled, oo.retryConfig, defaultRetryOn, log.withModifiedString(s => s"$prefix: $s"))
 
   /// Streams
 

--- a/core/src/main/scala/sec/client/options.scala
+++ b/core/src/main/scala/sec/client/options.scala
@@ -32,14 +32,16 @@ private[sec] object Options {
     private def modifyOO(fn: OperationOptions => OperationOptions): Options =
       o.copy(operationOptions = fn(o.operationOptions))
 
-    def withSecureMode(certChain: Path): Options                 = o.copy(connectionMode = Secure(certChain))
-    def withInsecureMode: Options                                = o.copy(connectionMode = Insecure)
-    def withConnectionName(name: String): Options                = o.copy(connectionName = name)
-    def withCredentials(creds: Option[UserCredentials]): Options = o.copy(credentials = creds)
-    def withOperationsRetryDelay(delay: FiniteDuration): Options = modifyOO(_.copy(retryDelay = delay))
-    def withOperationsMaxAttempts(max: Int): Options             = modifyOO(_.copy(retryMaxAttempts = max))
-    def withOperationsRetryEnabled: Options                      = modifyOO(_.copy(retryEnabled = true))
-    def withOperationsRetryDisabled: Options                     = modifyOO(_.copy(retryEnabled = false))
+    def withSecureMode(certChain: Path): Options                    = o.copy(connectionMode = Secure(certChain))
+    def withInsecureMode: Options                                   = o.copy(connectionMode = Insecure)
+    def withConnectionName(name: String): Options                   = o.copy(connectionName = name)
+    def withCredentials(creds: Option[UserCredentials]): Options    = o.copy(credentials = creds)
+    def withOperationsRetryDelay(delay: FiniteDuration): Options    = modifyOO(_.copy(retryDelay = delay))
+    def withOperationsRetryMaxDelay(delay: FiniteDuration): Options = modifyOO(_.copy(retryMaxDelay = delay))
+    def withOperationsRetryMaxAttempts(max: Int): Options           = modifyOO(_.copy(retryMaxAttempts = max))
+    def withOperationsRetryBackoffFactor(factor: Double)            = modifyOO(_.copy(retryBackoffFactor = factor))
+    def withOperationsRetryEnabled: Options                         = modifyOO(_.copy(retryEnabled = true))
+    def withOperationsRetryDisabled: Options                        = modifyOO(_.copy(retryEnabled = false))
   }
 
 }
@@ -51,3 +53,5 @@ private[sec] object ConnectionMode {
   case object Insecure                     extends ConnectionMode
   final case class Secure(certChain: Path) extends ConnectionMode
 }
+
+//======================================================================================================================

--- a/core/src/test/scala/sec/api/ITest.scala
+++ b/core/src/test/scala/sec/api/ITest.scala
@@ -10,7 +10,7 @@ import cats.effect.testing.specs2.CatsIO
 import cats.effect._
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.lyranthe.fs2_grpc.java_runtime.implicits._
-import io.grpc.netty.shaded.io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
+import io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
 import sec.core._
 import sec.client._
 import Arbitraries._
@@ -42,7 +42,7 @@ trait ITest extends Specification with CatsIO with AfterAll {
         .overrideAuthority(authority)
     )
 
-    val options = Options.default.withOperationsMaxAttempts(3)
+    val options = Options.default.withOperationsRetryMaxAttempts(3)
 
     val result: Resource[IO, EsClient[IO]] = for {
       b <- Resource.liftF(builder)

--- a/core/src/test/scala/sec/api/cluster/watch.scala
+++ b/core/src/test/scala/sec/api/cluster/watch.scala
@@ -29,8 +29,11 @@ class ClusterWatchSpec extends Specification with CatsIO {
 
     "only emit changes in cluster info" >> {
 
-      val settings =
-        ClusterSettings(1.some, 100.millis, RetryStrategy.Identity, 100.millis, 100.millis, NodePreference.Leader)
+      val settings = ClusterSettings.default
+        .withMaxDiscoverAttempts(1.some)
+        .withRetryMaxDelay(100.millis)
+        .withReadTimeout(100.millis)
+
       def instanceId = sampleOf[ju.UUID]
       def timestamp  = sampleOf[ZonedDateTime]
 
@@ -72,14 +75,13 @@ class ClusterWatchSpec extends Specification with CatsIO {
     "retry retriable errors until discovery attempts used" >> {
 
       val maxAttempts = 5
-      val settings = ClusterSettings(
-        maxDiscoverAttempts  = maxAttempts.some,
-        retryDelay           = 50.millis,
-        retryStrategy        = RetryStrategy.Identity,
-        readTimeout          = 50.millis,
-        notificationInterval = 50.millis,
-        preference           = NodePreference.Leader
-      )
+
+      val settings = ClusterSettings.default
+        .withMaxDiscoverAttempts(maxAttempts.some)
+        .withRetryDelay(50.millis)
+        .withRetryBackoffFactor(1)
+        .withReadTimeout(50.millis)
+        .withNotificationInterval(50.millis)
 
       def test(err: Throwable, count: Int) = {
 
@@ -111,14 +113,12 @@ class ClusterWatchSpec extends Specification with CatsIO {
       implicit val ec: TestContext      = TestContext()
       implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
-      val settings = ClusterSettings(
-        maxDiscoverAttempts  = 3.some,
-        retryDelay           = 50.millis,
-        retryStrategy        = RetryStrategy.Identity,
-        readTimeout          = 50.millis,
-        notificationInterval = 50.millis,
-        preference           = NodePreference.Leader
-      )
+      val settings = ClusterSettings.default
+        .withMaxDiscoverAttempts(3.some)
+        .withRetryDelay(50.millis)
+        .withRetryBackoffFactor(1)
+        .withReadTimeout(50.millis)
+        .withNotificationInterval(50.millis)
 
       val error = sampleOfGen(Gen.oneOf(ServerUnavailable("Oh Noes"), new TimeoutException("Oh Noes")))
 

--- a/netty/src/main/scala/sec/client/netty.scala
+++ b/netty/src/main/scala/sec/client/netty.scala
@@ -4,10 +4,10 @@ package client
 import java.nio.file.Path
 import cats.effect._
 import cats.implicits._
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder.{forAddress, forTarget}
-import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts.forClient
-import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext
+import io.grpc.netty.NettyChannelBuilder
+import io.grpc.netty.NettyChannelBuilder.{forAddress, forTarget}
+import io.grpc.netty.GrpcSslContexts.forClient
+import io.netty.handler.ssl.SslContext
 
 private[sec] object netty {
 

--- a/netty/src/main/scala/sec/client/package.scala
+++ b/netty/src/main/scala/sec/client/package.scala
@@ -1,17 +1,14 @@
 package sec
 
 import cats.effect._
-import fs2.Stream
 
 package object client {
 
   implicit final class SingleNodeBuilderOps[F[_]: ConcurrentEffect: Timer](val b: SingleNodeBuilder[F]) {
-    def stream: Stream[F, EsClient[F]]     = Stream.resource[F, EsClient[F]](resource)
     def resource: Resource[F, EsClient[F]] = b.build(netty.mkBuilder[F])
   }
 
   implicit final class ClusterBuilderOps[F[_]: ConcurrentEffect: Timer](val b: ClusterBuilder[F]) {
-    def stream: Stream[F, EsClient[F]]     = Stream.resource[F, EsClient[F]](resource)
     def resource: Resource[F, EsClient[F]] = b.build(netty.mkBuilder[F])
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
     val circe             = "0.13.0"
     val scalaPb           = scalapb.compiler.Version.scalapbVersion
     val grpc              = org.lyranthe.fs2_grpc.buildinfo.BuildInfo.grpcVersion
+    val tcnative          = "2.0.30.Final"
     val disciplineSpecs2  = "1.1.0"
     val specs2            = "4.10.3"
     val catsEffectTesting = "0.4.1"
@@ -33,18 +34,19 @@ object Dependencies {
 
   // Testing & Demo
 
-  val specs2            = "org.specs2"        %% "specs2-core"                % versions.specs2
-  val specs2ScalaCheck  = "org.specs2"        %% "specs2-scalacheck"          % versions.specs2
-  val specs2Cats        = "org.specs2"        %% "specs2-cats"                % versions.specs2
-  val circeGeneric      = "io.circe"          %% "circe-generic"              % versions.circe
-  val disciplineSpecs2  = "org.typelevel"     %% "discipline-specs2"          % versions.disciplineSpecs2
-  val catsLaws          = "org.typelevel"     %% "cats-laws"                  % versions.catsCore
-  val catsEffectTesting = "com.codecommit"    %% "cats-effect-testing-specs2" % versions.catsEffectTesting
-  val catsEffectLaws    = "org.typelevel"     %% "cats-effect-laws"           % versions.catsEffect
-  val logback           = "ch.qos.logback"     % "logback-classic"            % versions.logback
-  val log4catsNoop      = "io.chrisdavenport" %% "log4cats-noop"              % versions.log4cats
-  val log4catsSlf4j     = "io.chrisdavenport" %% "log4cats-slf4j"             % versions.log4cats
-  val grpcNetty         = "io.grpc"            % "grpc-netty-shaded"          % versions.grpc
+  val specs2            = "org.specs2"        %% "specs2-core"                     % versions.specs2
+  val specs2ScalaCheck  = "org.specs2"        %% "specs2-scalacheck"               % versions.specs2
+  val specs2Cats        = "org.specs2"        %% "specs2-cats"                     % versions.specs2
+  val circeGeneric      = "io.circe"          %% "circe-generic"                   % versions.circe
+  val disciplineSpecs2  = "org.typelevel"     %% "discipline-specs2"               % versions.disciplineSpecs2
+  val catsLaws          = "org.typelevel"     %% "cats-laws"                       % versions.catsCore
+  val catsEffectTesting = "com.codecommit"    %% "cats-effect-testing-specs2"      % versions.catsEffectTesting
+  val catsEffectLaws    = "org.typelevel"     %% "cats-effect-laws"                % versions.catsEffect
+  val logback           = "ch.qos.logback"     % "logback-classic"                 % versions.logback
+  val log4catsNoop      = "io.chrisdavenport" %% "log4cats-noop"                   % versions.log4cats
+  val log4catsSlf4j     = "io.chrisdavenport" %% "log4cats-slf4j"                  % versions.log4cats
+  val grpcNetty         = "io.grpc"            % "grpc-netty"                      % versions.grpc
+  val tcnative          = "io.netty"           % "netty-tcnative-boringssl-static" % versions.tcnative
 
   // Compiler & SBT Plugins
 


### PR DESCRIPTION
 - remove grpc-netty-shaded and rather use normal + tcnative
   for now.

 - remove streams extension methods from builders as it is trivial to
   do in user code.

 - make all params for builds required as this opens up for reading
   config via lightbend config and apply changes to default `Options`
   and `ClusterSettings` before using builders to bake an `EsClient`.

 - move retry logic to retries object with log helpers. Ok for now.