### PR TITLE
core: shutdown delay for channel + weaver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val `sec-tests` = project
     skip in publish := true,
     buildInfoPackage := "sec",
     buildInfoKeys := Seq(BuildInfoKey("certsPath" -> file("").getAbsoluteFile.toPath / "certs")),
+    testFrameworks += new TestFramework("weaver.framework.TestFramework"),
     Test / headerSources ++= sources.in(SingleNodeITest).value ++ sources.in(ClusterITest).value,
     libraryDependencies ++= testM(
       catsLaws,
@@ -58,6 +59,8 @@ lazy val `sec-tests` = project
       specs2Cats,
       catsEffectTesting,
       catsEffectLaws,
+      weawer,
+      weawerSpecs,
       log4catsSlf4j,
       logback
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
     val disciplineSpecs2  = "1.1.0"
     val specs2            = "4.10.3"
     val catsEffectTesting = "0.4.1"
+    val weaver            = "0.4.3"
 
   }
 
@@ -34,18 +35,20 @@ object Dependencies {
 
   // Testing & Demo
 
-  val specs2            = "org.specs2"        %% "specs2-core"                     % versions.specs2
-  val specs2ScalaCheck  = "org.specs2"        %% "specs2-scalacheck"               % versions.specs2
-  val specs2Cats        = "org.specs2"        %% "specs2-cats"                     % versions.specs2
-  val disciplineSpecs2  = "org.typelevel"     %% "discipline-specs2"               % versions.disciplineSpecs2
-  val catsLaws          = "org.typelevel"     %% "cats-laws"                       % versions.catsCore
-  val catsEffectTesting = "com.codecommit"    %% "cats-effect-testing-specs2"      % versions.catsEffectTesting
-  val catsEffectLaws    = "org.typelevel"     %% "cats-effect-laws"                % versions.catsEffect
-  val logback           = "ch.qos.logback"     % "logback-classic"                 % versions.logback
-  val log4catsNoop      = "io.chrisdavenport" %% "log4cats-noop"                   % versions.log4cats
-  val log4catsSlf4j     = "io.chrisdavenport" %% "log4cats-slf4j"                  % versions.log4cats
-  val grpcNetty         = "io.grpc"            % "grpc-netty"                      % versions.grpc
-  val tcnative          = "io.netty"           % "netty-tcnative-boringssl-static" % versions.tcnative
+  val specs2            = "org.specs2"          %% "specs2-core"                     % versions.specs2
+  val specs2ScalaCheck  = "org.specs2"          %% "specs2-scalacheck"               % versions.specs2
+  val specs2Cats        = "org.specs2"          %% "specs2-cats"                     % versions.specs2
+  val disciplineSpecs2  = "org.typelevel"       %% "discipline-specs2"               % versions.disciplineSpecs2
+  val catsLaws          = "org.typelevel"       %% "cats-laws"                       % versions.catsCore
+  val catsEffectLaws    = "org.typelevel"       %% "cats-effect-laws"                % versions.catsEffect
+  val weawer            = "com.disneystreaming" %% "weaver-framework"                % versions.weaver
+  val weawerSpecs       = "com.disneystreaming" %% "weaver-specs2"                   % versions.weaver
+  val catsEffectTesting = "com.codecommit"      %% "cats-effect-testing-specs2"      % versions.catsEffectTesting
+  val logback           = "ch.qos.logback"       % "logback-classic"                 % versions.logback
+  val log4catsNoop      = "io.chrisdavenport"   %% "log4cats-noop"                   % versions.log4cats
+  val log4catsSlf4j     = "io.chrisdavenport"   %% "log4cats-slf4j"                  % versions.log4cats
+  val grpcNetty         = "io.grpc"              % "grpc-netty"                      % versions.grpc
+  val tcnative          = "io.netty"             % "netty-tcnative-boringssl-static" % versions.tcnative
 
   // Misc
 

--- a/sec-core/src/main/scala/sec/api/cluster/settings.scala
+++ b/sec-core/src/main/scala/sec/api/cluster/settings.scala
@@ -29,7 +29,8 @@ final private[sec] case class ClusterSettings(
   retryBackoffFactor: Double,
   readTimeout: FiniteDuration,
   notificationInterval: FiniteDuration,
-  preference: NodePreference
+  preference: NodePreference,
+  channelShutdownAwait: FiniteDuration
 )
 
 private[sec] object ClusterSettings {
@@ -41,7 +42,8 @@ private[sec] object ClusterSettings {
     retryBackoffFactor   = 1.25,
     readTimeout          = 5.seconds,
     notificationInterval = 100.millis,
-    preference           = NodePreference.Leader
+    preference           = NodePreference.Leader,
+    channelShutdownAwait = 10.seconds
   )
 
   implicit final class ClusterSettingsOps(val cs: ClusterSettings) extends AnyVal {
@@ -53,6 +55,7 @@ private[sec] object ClusterSettings {
     def withReadTimeout(timeout: FiniteDuration): ClusterSettings           = cs.copy(readTimeout = timeout)
     def withNotificationInterval(interval: FiniteDuration): ClusterSettings = cs.copy(notificationInterval = interval)
     def withNodePreference(np: NodePreference): ClusterSettings             = cs.copy(preference = np)
+    def withChannelShutdownAwait(await: FiniteDuration): ClusterSettings    = cs.copy(channelShutdownAwait = await)
 
     def retryConfig: RetryConfig = RetryConfig(
       cs.retryDelay,

--- a/sec-core/src/main/scala/sec/api/cluster/watch.scala
+++ b/sec-core/src/main/scala/sec/api/cluster/watch.scala
@@ -25,9 +25,9 @@ import cats.effect._
 import cats.effect.concurrent.Ref
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
-import org.lyranthe.fs2_grpc.java_runtime.implicits._
 import io.grpc._
 import core.{NotLeader, ServerUnavailable}
+import sec.syntax.channel._
 import sec.api.Gossip.ClusterInfo
 import sec.api.cluster.grpc._
 import sec.api.retries._
@@ -56,7 +56,7 @@ private[sec] object ClusterWatch {
 
     def mkChannel(p: ResolverProvider[F]): Resource[F, ManagedChannel] = Resource
       .liftF(builderFromTarget(s"${p.scheme}:///"))
-      .flatMap(_.defaultLoadBalancingPolicy("round_robin").resource[F])
+      .flatMap(_.defaultLoadBalancingPolicy("round_robin").resource[F](settings.channelShutdownAwait))
 
     for {
       store    <- mkCache

--- a/sec-core/src/main/scala/sec/client/client.scala
+++ b/sec-core/src/main/scala/sec/client/client.scala
@@ -17,6 +17,7 @@
 package sec
 package client
 
+import scala.concurrent.duration._
 import cats.Endo
 import cats.data.NonEmptySet
 import cats.effect.{ConcurrentEffect, Timer}
@@ -39,7 +40,7 @@ trait EsClient[F[_]] {
 object EsClient {
 
   def single[F[_]: ConcurrentEffect: Timer](endpoint: Endpoint): SingleNodeBuilder[F] =
-    SingleNodeBuilder[F](endpoint, None, Options.default, NoOpLogger.impl[F])
+    SingleNodeBuilder[F](endpoint, None, Options.default, 10.seconds, logger = NoOpLogger.impl[F])
 
   def cluster[F[_]: ConcurrentEffect: Timer](seed: NonEmptySet[Endpoint], authority: String): ClusterBuilder[F] =
     ClusterBuilder[F](seed, authority, Options.default, ClusterSettings.default, NoOpLogger.impl[F])

--- a/sec-core/src/main/scala/sec/syntax/channel.scala
+++ b/sec-core/src/main/scala/sec/syntax/channel.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Alex Henning Johannessen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package syntax
+
+import scala.concurrent.blocking
+import scala.concurrent.duration._
+import cats.effect.{Resource, Sync}
+import io.grpc.{ManagedChannel, ManagedChannelBuilder}
+
+private[sec] object channel {
+
+  implicit final class ManagedChannelBuilderOps[MCB <: ManagedChannelBuilder[MCB]](val mcb: MCB) extends AnyVal {
+
+    def resource[F[_]: Sync](shutdownAwait: FiniteDuration): Resource[F, ManagedChannel] =
+      resourceWithShutdown[F] { ch =>
+        Sync[F].delay {
+          ch.shutdown()
+          if (!blocking(ch.awaitTermination(shutdownAwait.length, shutdownAwait.unit))) {
+            ch.shutdownNow()
+            ()
+          }
+        }
+      }
+
+    def resourceWithShutdown[F[_]: Sync](shutdown: ManagedChannel => F[Unit]): Resource[F, ManagedChannel] =
+      Resource.make(Sync[F].delay(mcb.build()))(shutdown)
+
+  }
+
+}

--- a/sec-tests/src/cit/scala/sec/api/cluster.scala
+++ b/sec-tests/src/cit/scala/sec/api/cluster.scala
@@ -20,25 +20,19 @@ package api
 import scala.concurrent.duration._
 import cats.implicits._
 
-class ClusterTest extends CTest {
+object ClusterSuite extends CIOSuite {
 
-  sequential
-
-  "Cluster" should {
-
-    "be reachable" >> withGossipL { (gossip, log) =>
-      fs2.Stream
-        .eval(gossip.read(None))
-        .evalTap(x => log.info(s"Gossip.read: ${x.show}"))
-        .metered(150.millis)
-        .repeat
-        .take(5)
-        .compile
-        .lastOrError
-        .map(_.members)
-        .map(m => (m.size shouldEqual 3) and (m.forall(_.isAlive) should beTrue))
-    }
-
+  test("cluster should be reachable") { (cl, log) =>
+    fs2.Stream
+      .eval(cl.gossip.read(None))
+      .evalTap(x => log.info(s"Gossip.read: ${x.show}"))
+      .metered(150.millis)
+      .repeat
+      .take(5)
+      .compile
+      .lastOrError
+      .map(_.members)
+      .map(m => (m.size mustEqual 3) and (m.forall(_.isAlive) must beTrue))
   }
 
 }

--- a/sec-tests/src/cit/scala/sec/api/csuite.scala
+++ b/sec-tests/src/cit/scala/sec/api/csuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Alex Henning Johannessen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import java.io.File
+import scala.concurrent.duration._
+import org.specs2.matcher.StandardMatchResults
+import weaver.specs2compat.IOMatchers
+import weaver.IOSuite
+import cats.data.NonEmptySet
+import cats.effect._
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import helpers.text.snakeCaseTransformation
+import helpers.endpoint.endpointFrom
+import sec.client._
+
+trait CIOSuite extends IOSuite with IOMatchers with StandardMatchResults {
+  import CIOSuite._
+
+  type Res = EsClient[IO]
+
+  final def sharedResource: Resource[IO, EsClient[IO]] = for {
+    log <- Resource.liftF(Slf4jLogger.fromName[IO](snakeCaseTransformation(getClass.getSimpleName)))
+    client <- EsClient
+                .cluster[IO](seed, authority)
+                .withChannelShutdownAwait(0.seconds)
+                .withCertificate(ca.toPath)
+                .withLogger(log)
+                .resource
+  } yield client
+}
+
+object CIOSuite {
+
+  final private val certsFolder = new File(sys.env.getOrElse("SEC_CLUSTER_CERTS_PATH", BuildInfo.certsPath))
+  final private val ca          = new File(certsFolder, "ca/ca.crt")
+  final private val authority   = sys.env.getOrElse("SEC_CLUSTER_AUTHORITY", "es.sec.local")
+  final private val seed = NonEmptySet.of(
+    endpointFrom("SEC_CLUSTER_ES1_ADDRESS", "SEC_CLUSTER_ES1_PORT", "127.0.0.1", 2114),
+    endpointFrom("SEC_CLUSTER_ES2_ADDRESS", "SEC_CLUSTER_ES2_PORT", "127.0.0.1", 2115),
+    endpointFrom("SEC_CLUSTER_ES3_ADDRESS", "SEC_CLUSTER_ES3_PORT", "127.0.0.1", 2116)
+  )
+
+}

--- a/sec-tests/src/sit/scala/sec/api/gossip.scala
+++ b/sec-tests/src/sit/scala/sec/api/gossip.scala
@@ -33,6 +33,6 @@ class GossipITest extends ITest {
           case Some(MemberInfo(_, _, VNodeState.Leader, true, Endpoint("127.0.0.1", 2113))) => ok
         })
     }
-
   }
+
 }

--- a/sec-tests/src/sit/scala/sec/api/isuite.scala
+++ b/sec-tests/src/sit/scala/sec/api/isuite.scala
@@ -19,11 +19,12 @@ package api
 
 import java.io.File
 import scala.concurrent.duration._
-import org.specs2.mutable.Specification
-import org.specs2.specification.AfterAll
 import org.scalacheck.Gen
+import org.specs2.matcher.StandardMatchResults
+import weaver.specs2compat.IOMatchers
+import weaver.IOSuite
+import cats.Endo
 import cats.data.{NonEmptyList => Nel}
-import cats.effect.testing.specs2._
 import cats.effect._
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import helpers.text.snakeCaseTransformation
@@ -31,51 +32,41 @@ import sec.core._
 import sec.client._
 import Arbitraries._
 
-trait ITest extends Specification with CatsIO with AfterAll {
+abstract class IIOSuite extends IOSuite with IOMatchers with StandardMatchResults {
+  import IIOSuite._
 
-  import ITest._
+  type Res = EsClient[IO]
 
-  final private val testName                              = snakeCaseTransformation(getClass.getSimpleName)
+  final private val testName: String = snakeCaseTransformation(getClass.getSimpleName)
+
+  protected def builderCfg: Endo[SingleNodeBuilder[IO]] = identity
+
+  final def sharedResource: Resource[IO, EsClient[IO]] = for {
+    log    <- Resource.liftF(Slf4jLogger.fromName[IO](snakeCaseTransformation(getClass.getSimpleName)))
+    builder = builderCfg(EsClient.single[IO](endpoint))
+    client <- builder
+                .withChannelShutdownAwait(0.seconds)
+                .withAuthority(authority)
+                .withCertificate(ca.toPath)
+                .withLogger(log)
+                .resource
+  } yield client
+
   def genIdentifier: String                               = sampleOfGen(Gen.identifier.suchThat(id => id.length >= 5 && id.length <= 20))
   def genStreamId: StreamId.Id                            = genStreamId(s"${testName}_")
   def genStreamId(streamPrefix: String): StreamId.Id      = sampleOfGen(idGen.genStreamIdNormal(s"$streamPrefix"))
   def genEvents(n: Int): Nel[EventData]                   = genEvents(n, eventTypeGen.defaultPrefix)
   def genEvents(n: Int, etPrefix: String): Nel[EventData] = sampleOfGen(eventdataGen.eventDataNelN(n, etPrefix))
 
-  final private lazy val (client, shutdown): (EsClient[IO], IO[Unit]) = {
-
-    val resource: Resource[IO, EsClient[IO]] = for {
-      log <- Resource.liftF(Slf4jLogger.fromName[IO](snakeCaseTransformation(getClass.getSimpleName)))
-      client <- EsClient
-                  .single[IO](endpoint)
-                  .withAuthority(authority)
-                  .withCertificate(ca.toPath)
-                  .withChannelShutdownAwait(0.seconds)
-                  .withOperationsRetryMaxAttempts(3)
-                  .withLogger(log)
-                  .resource
-    } yield client
-
-    resource.allocated[IO, EsClient[IO]].unsafeRunSync()
-  }
-
-  final def esClient: EsClient[IO] = client
-  final def streams: Streams[IO]   = client.streams
-  final def gossip: Gossip[IO]     = client.gossip
-
-  //
-
-  final def afterAll(): Unit = shutdown.unsafeRunSync()
-
 }
 
-object ITest {
+object IIOSuite {
 
   final private val certsFolder = new File(sys.env.getOrElse("SEC_TEST_CERTS_PATH", BuildInfo.certsPath))
   final private val address     = sys.env.getOrElse("SEC_IT_TEST_HOST_ADDRESS", "127.0.0.1")
   final private val port        = sys.env.get("SEC_IT_TEST_HOST_PORT").flatMap(_.toIntOption).getOrElse(2113)
-  final private val ca          = new File(certsFolder, "ca/ca.crt")
   final private val endpoint    = Endpoint(address, port)
+  final private val ca          = new File(certsFolder, "ca/ca.crt")
   final private val authority   = sys.env.getOrElse("SEC_IT_TEST_AUTHORITY", "es.sec.local")
 
 }

--- a/sec-tests/src/sit/scala/sec/api/streams.scala
+++ b/sec-tests/src/sit/scala/sec/api/streams.scala
@@ -27,13 +27,6 @@ import fs2.Stream
 import sec.core._
 import sec.api.Direction._
 
-/* TODO:
-  When using builder / resource the test takes 30 seconds longer to complete.
-  Tests themselves run as fast, but the shutdown is hanging in subscribeToStream.
-  Needs to be investigated further and consider replacing specs with munit for these
-  types of tests.
- */
-
 class StreamsITest extends ITest {
 
   sequential


### PR DESCRIPTION
 - experiment with weaver testing framework
 - set shutdown delay for managed channels in tests to 0 seconds.