### PR TITLE
docker: switch to disk storage for single node

### DIFF
--- a/.docker/single-node.ci.yml
+++ b/.docker/single-node.ci.yml
@@ -6,7 +6,6 @@ services:
     env_file:
       - shared.env
     environment:
-      - EVENTSTORE_MEM_DB=True
       - EVENTSTORE_GOSSIP_ON_SINGLE_NODE=True
       - EVENTSTORE_START_STANDARD_PROJECTIONS=True
     volumes:


### PR DESCRIPTION
 - `subscribeToStream` test for non-present stream is flaky and maybe this improves it.