### PR TITLE
core/tests: tests for subscribe to all + id + write result

### DIFF
--- a/sec-core/src/main/scala/sec/api/streams.scala
+++ b/sec-core/src/main/scala/sec/api/streams.scala
@@ -97,7 +97,7 @@ trait Streams[F[_]] {
 
 object Streams {
 
-  final case class WriteResult(currentRevision: EventNumber.Exact)
+  final case class WriteResult(currentRevision: EventNumber.Exact, position: Position.Exact)
   final case class DeleteResult(position: Position.Exact)
 
 //======================================================================================================================

--- a/sec-core/src/main/scala/sec/core/id.scala
+++ b/sec-core/src/main/scala/sec/core/id.scala
@@ -106,7 +106,18 @@ object StreamId {
   ///
 
   implicit final class StreamIdOps(val sid: StreamId) extends AnyVal {
-    def stringValue: String = streamIdToString(sid)
+
+    private[sec] def fold[A](nfn: NormalId => A, sfn: SystemId => A, mfn: MetaId => A): A =
+      sid match {
+        case n: NormalId => nfn(n)
+        case s: SystemId => sfn(s)
+        case m: MetaId   => mfn(m)
+      }
+
+    def stringValue: String     = streamIdToString(sid)
+    def isNormal: Boolean       = fold(_ => true, _ => false, _ => false)
+    def isSystemOrMeta: Boolean = fold(_ => false, _ => true, _ => true)
+
   }
 
   implicit final class IdOps(val id: Id) extends AnyVal {

--- a/sec-tests/src/test/scala/sec/core/id.scala
+++ b/sec-tests/src/test/scala/sec/core/id.scala
@@ -92,10 +92,30 @@ class StreamIdSpec extends Specification with Discipline {
   }
 
   "StreamIdOps" >> {
+
+    "fold" >> {
+      normalId.fold(_ => true, _ => false, _ => false) should beTrue
+      systemId.fold(_ => false, _ => true, _ => false) should beTrue
+      List(normalId, systemId).map(_.metaId.fold(_ => false, _ => false, _ => true)).forall(identity) should beTrue
+    }
+
     "stringValue" >> {
       val sid = sampleOf[StreamId]
       sid.stringValue shouldEqual StreamId.streamIdToString(sid)
     }
+
+    "isNormalStream" >> {
+      normalId.isNormal should beTrue
+      systemId.isNormal should beFalse
+      List(normalId, systemId).map(_.metaId.isNormal).forall(identity) should beFalse
+    }
+
+    "isSystemOrMeta" >> {
+      normalId.isSystemOrMeta should beFalse
+      systemId.isSystemOrMeta should beTrue
+      List(normalId, systemId).map(_.metaId.isSystemOrMeta).forall(identity) should beTrue
+    }
+
   }
 
   "IdOps" >> {


### PR DESCRIPTION
- add tests for `subscribeToAll`.
- add `Position` to `WriteResult`.
- add `isNormal` and `isSystemOrMeta` ops for `Id`.