### PR TITLE
core: subscribe to all filtered tests / tweaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,14 @@ lazy val `sec-tests` = project
   .enablePlugins(BuildInfoPlugin, AutomateHeaderPlugin)
   .configs(SingleNodeITest, ClusterITest)
   .settings(commonSettings)
-  .settings(inConfig(SingleNodeITest)(Defaults.testSettings ++ Seq(parallelExecution := false)))
+  .settings(inConfig(SingleNodeITest)(Defaults.testSettings ++ Seq(
+    parallelExecution := false,
+    javaOptions ++= Seq(
+      "-Dcats.effect.global_scheduler.threads.core_pool_size=4",
+      "-Dcats.effect.global_scheduler.keep_alive_time_ms=10000"
+    ),
+    fork := true
+  )))
   .settings(inConfig(ClusterITest)(Defaults.testSettings ++ Seq(parallelExecution := false)))
   .settings(
     skip in publish := true,

--- a/sec-tests/src/main/scala/sec/specs.scala
+++ b/sec-tests/src/main/scala/sec/specs.scala
@@ -40,7 +40,7 @@ trait ResourceSpec[A] extends Specification with AfterAll with CatsIO {
 
 trait ClientSpec extends ResourceSpec[EsClient[IO]] {
 
-  override val Timeout: Duration = 120.seconds
+  override val Timeout: Duration = 90.seconds
 
   final def client: EsClient[IO]         = resource
   final def streams: Streams[IO]         = client.streams

--- a/sec-tests/src/test/scala/sec/api/filter.scala
+++ b/sec-tests/src/test/scala/sec/api/filter.scala
@@ -30,16 +30,15 @@ class EventFilterSpec extends Specification with ScalaCheck {
   "EventFilter" >> {
 
     implicit val arbKind: Arbitrary[Kind]   = Arbitrary(Gen.oneOf[Kind](ByStreamId, ByEventType))
-    implicit val arbMax: Arbitrary[Int]     = Arbitrary(Gen.posNum[Int])
     implicit val arbRegex: Arbitrary[Regex] = Arbitrary(Gen.oneOf("^ctx1__.*".r, "^[^$].*".r))
 
-    "prefix" >> prop { (k: Kind, msw: Option[Int], fst: String, rest: List[String]) =>
-      prefix(k, msw, fst, rest: _*) shouldEqual
-        EventFilter(k, msw, NonEmptyList(PrefixFilter(fst), rest.map(PrefixFilter)).asLeft)
+    "prefix" >> prop { (k: Kind, fst: String, rest: List[String]) =>
+      prefix(k, fst, rest: _*) shouldEqual
+        EventFilter(k, NonEmptyList(PrefixFilter(fst), rest.map(PrefixFilter)).asLeft)
     }
 
-    "regex" >> prop { (k: Kind, msw: Option[Int], filter: Regex) =>
-      regex(k, msw, filter.pattern.toString) shouldEqual EventFilter(k, msw, RegexFilter(filter).asRight)
+    "regex" >> prop { (k: Kind, filter: Regex) =>
+      regex(k, filter.pattern.toString) shouldEqual EventFilter(k, RegexFilter(filter).asRight)
     }
 
   }


### PR DESCRIPTION
 - tweaks to build in order to get CI to run less
   flaky.

 - remove max search window from filter.

 - add `SubscriptionFilterOptions` that has filter,
   max search window and checkpoint interval multiplier.