### PR TITLE
core: cleanup subscribe to all related / tweaks

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Delete artifacts
         run: |
           # Customize those three lines with your repository and credentials:
-          REPO=https://api.github.com/repos/$1
+          REPO=${GITHUB_API_URL}/repos/${{ github.repository }}
 
           # A shortcut to call GitHub API.
           ghapi() { curl --silent --location --user _:$GITHUB_TOKEN "$@"; }

--- a/build.sbt
+++ b/build.sbt
@@ -39,13 +39,17 @@ lazy val `sec-netty` = project
 lazy val SingleNodeITest = config("sit") extend Test
 lazy val ClusterITest    = config("cit") extend Test
 
+lazy val integrationSettings = Defaults.testSettings ++ Seq(
+  parallelExecution := false
+)
+
 lazy val `sec-tests` = project
   .in(file("sec-tests"))
   .enablePlugins(BuildInfoPlugin, AutomateHeaderPlugin)
   .configs(SingleNodeITest, ClusterITest)
   .settings(commonSettings)
-  .settings(inConfig(SingleNodeITest)(Defaults.testSettings ++ Seq(parallelExecution := false)))
-  .settings(inConfig(ClusterITest)(Defaults.testSettings ++ Seq(parallelExecution := false)))
+  .settings(inConfig(SingleNodeITest)(integrationSettings))
+  .settings(inConfig(ClusterITest)(integrationSettings))
   .settings(
     skip in publish := true,
     buildInfoPackage := "sec",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("ch.epfl.lamp"              % "sbt-dotty"          % "0.4.2")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"       % "0.1.13")
-addSbtPlugin("com.codecommit"            % "sbt-github-actions" % "0.9.2")
+addSbtPlugin("com.codecommit"            % "sbt-github-actions" % "0.9.3")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"         % "5.6.0")
 addSbtPlugin("com.geirsson"              % "sbt-ci-release"     % "1.5.3")
 addSbtPlugin("org.lyranthe.fs2-grpc"     % "sbt-java-gen"       % "0.7.3")

--- a/sec-core/src/main/scala/sec/api/filter.scala
+++ b/sec-core/src/main/scala/sec/api/filter.scala
@@ -26,7 +26,6 @@ import EventFilter._
 
 final case class EventFilter(
   kind: Kind,
-  maxSearchWindow: Option[Int],
   option: Either[NonEmptyList[PrefixFilter], RegexFilter]
 )
 
@@ -36,11 +35,16 @@ object EventFilter {
   case object ByStreamId  extends Kind
   case object ByEventType extends Kind
 
-  def prefix(kind: Kind, maxSearchWindow: Option[Int], fst: String, rest: String*): EventFilter =
-    EventFilter(kind, maxSearchWindow, NonEmptyList(PrefixFilter(fst), rest.toList.map(PrefixFilter)).asLeft)
+  def streamIdPrefix(fst: String, rest: String*): EventFilter  = prefix(ByStreamId, fst, rest: _*)
+  def streamIdRegex(filter: String): EventFilter               = regex(ByStreamId, filter)
+  def eventTypePrefix(fst: String, rest: String*): EventFilter = prefix(ByEventType, fst, rest: _*)
+  def eventTypeRegex(filter: String): EventFilter              = regex(ByEventType, filter)
 
-  def regex(kind: Kind, maxSearchWindow: Option[Int], filter: String): EventFilter =
-    EventFilter(kind, maxSearchWindow, RegexFilter(filter).asRight)
+  def prefix(kind: Kind, fst: String, rest: String*): EventFilter =
+    EventFilter(kind, NonEmptyList(PrefixFilter(fst), rest.toList.map(PrefixFilter)).asLeft)
+
+  def regex(kind: Kind, filter: String): EventFilter =
+    EventFilter(kind, RegexFilter(filter).asRight)
 
   ///
 
@@ -49,9 +53,36 @@ object EventFilter {
   final case class RegexFilter(value: String)  extends Expression
 
   object RegexFilter {
-    val excludeSystemEvents: Regex       = "^[^$].*".r
+    val excludeSystemEvents: RegexFilter = apply("^[^$].*".r)
     def apply(regex: Regex): RegexFilter = RegexFilter(regex.pattern.toString)
   }
+
+}
+
+//======================================================================================================================
+
+sealed abstract case class SubscriptionFilterOptions(
+  filter: EventFilter,
+  maxSearchWindow: Option[Int],
+  checkpointIntervalMultiplier: Int
+)
+
+object SubscriptionFilterOptions {
+
+  /**
+   * @param filter See [[EventFilter]].
+   * @param maxSearchWindow Maximum number of events to read that do not match the filter.
+   *                        Minimum valid value is 1 and if provided value is less then 1 is used.
+   * @param checkpointIntervalMultiplier The checkpoint interval is multiplied by the max search window to
+   *                                     determine the number of events after which to checkpoint.
+   *                                     Minimum valid value is 1 and if provided value is less then 1 is used.
+   */
+  def apply(
+    filter: EventFilter,
+    maxSearchWindow: Option[Int] = 32.some,
+    checkpointIntervalMultiplier: Int = 1
+  ): SubscriptionFilterOptions =
+    new SubscriptionFilterOptions(filter, maxSearchWindow.map(_ max 1), checkpointIntervalMultiplier max 1) {}
 
 }
 

--- a/sec-core/src/main/scala/sec/api/mapping/streams.scala
+++ b/sec-core/src/main/scala/sec/api/mapping/streams.scala
@@ -18,7 +18,7 @@ package sec
 package api
 package mapping
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, OptionT}
 import cats.syntax.all._
 import com.eventstore.client._
 import com.eventstore.client.streams._
@@ -67,24 +67,29 @@ private[sec] object streams {
       case Direction.Backwards => ReadReq.Options.ReadDirection.Backwards
     }
 
-    val mapReadEventFilter: Option[EventFilter] => ReadReq.Options.FilterOption = {
+    val mapReadEventFilter: Option[SubscriptionFilterOptions] => ReadReq.Options.FilterOption = {
 
       import ReadReq.Options.FilterOption
 
-      def filter(filter: EventFilter): FilterOption = {
+      def filter(options: SubscriptionFilterOptions): FilterOption = {
 
-        val expr = filter.option.fold(
+        val expr = options.filter.option.fold(
           nel => ReadReq.Options.FilterOptions.Expression().withPrefix(nel.map(_.value).toList),
           reg => ReadReq.Options.FilterOptions.Expression().withRegex(reg.value)
         )
 
-        val window = filter.maxSearchWindow
+        val window = options.maxSearchWindow
           .map(ReadReq.Options.FilterOptions.Window.Max)
           .getOrElse(ReadReq.Options.FilterOptions.Window.Count(empty))
 
-        val result = filter.kind match {
-          case EventFilter.ByStreamId  => ReadReq.Options.FilterOptions().withStreamName(expr).withWindow(window)
-          case EventFilter.ByEventType => ReadReq.Options.FilterOptions().withEventType(expr).withWindow(window)
+        val filterOptions = ReadReq.Options
+          .FilterOptions()
+          .withWindow(window)
+          .withCheckpointIntervalMultiplier(options.checkpointIntervalMultiplier)
+
+        val result = options.filter.kind match {
+          case EventFilter.ByStreamId  => filterOptions.withStreamName(expr)
+          case EventFilter.ByEventType => filterOptions.withEventType(expr)
         }
 
         FilterOption.Filter(result)
@@ -116,7 +121,7 @@ private[sec] object streams {
     def mkSubscribeToAllReq(
       exclusiveFrom: Option[Position],
       resolveLinkTos: Boolean,
-      filter: Option[EventFilter]
+      filterOptions: Option[SubscriptionFilterOptions]
     ): ReadReq = {
 
       val options = ReadReq
@@ -125,7 +130,7 @@ private[sec] object streams {
         .withSubscription(ReadReq.Options.SubscriptionOptions())
         .withReadDirection(mapDirection(Direction.Forwards))
         .withResolveLinks(resolveLinkTos)
-        .withFilterOption(mapReadEventFilter(filter))
+        .withFilterOption(mapReadEventFilter(filterOptions))
         .withUuidOption(uuidOption)
 
       ReadReq().withOptions(options)
@@ -219,6 +224,20 @@ private[sec] object streams {
 //======================================================================================================================
 
   object incoming {
+
+    def mkCheckpoint[F[_]: ErrorA](c: ReadResp.Checkpoint): F[Checkpoint] = Position
+      .Exact(c.commitPosition, c.preparePosition)
+      .map(Checkpoint)
+      .leftMap(error => ProtoResultError(s"Invalid position for Checkpoint: $error"))
+      .liftTo[F]
+
+    def mkCheckpointOrEvent[F[_]: ErrorM](re: ReadResp): F[Option[Either[Checkpoint, Event]]] = {
+
+      val event      = OptionT(re.content.event.flatTraverse(mkEvent[F]).nested.map(_.asRight[Checkpoint]).value)
+      val checkpoint = OptionT(re.content.checkpoint.traverse(mkCheckpoint[F]).nested.map(_.asLeft[Event]).value)
+
+      (event <+> checkpoint).value
+    }
 
     def mkEvent[F[_]: ErrorM](re: ReadResp.ReadEvent): F[Option[Event]] =
       re.event.traverse(mkEventRecord[F]) >>= { eOpt =>

--- a/sec-tests/src/main/scala/sec/helpers.scala
+++ b/sec-tests/src/main/scala/sec/helpers.scala
@@ -25,7 +25,7 @@ object helpers {
 
     final private val basePattern: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
     final private val swapPattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
-    final val snakeCaseTransformation: String => String = s => {
+    final val mkSnakeCase: String => String = s => {
       val partial = basePattern.matcher(s).replaceAll("$1_$2")
       swapPattern.matcher(partial).replaceAll("$1_$2").toLowerCase
     }

--- a/sec-tests/src/main/scala/sec/specs.scala
+++ b/sec-tests/src/main/scala/sec/specs.scala
@@ -21,14 +21,14 @@ import cats.effect._
 import cats.effect.testing.specs2._
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
-import helpers.text.snakeCaseTransformation
+import helpers.text.mkSnakeCase
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import sec.client.EsClient
 import sec.api.{Gossip, MetaStreams, Streams}
 
 trait ResourceSpec[A] extends Specification with AfterAll with CatsIO {
-  final val testName                        = snakeCaseTransformation(getClass.getSimpleName)
+  final val testName                        = mkSnakeCase(getClass.getSimpleName)
   final private lazy val logger: Logger[IO] = Slf4jLogger.fromName[IO](testName).unsafeRunSync()
   final private lazy val (value, shutdown)  = makeResource.allocated[IO, A].unsafeRunSync()
   final override def afterAll(): Unit       = shutdown.unsafeRunSync()

--- a/sec-tests/src/sit/scala/sec/api/streams.scala
+++ b/sec-tests/src/sit/scala/sec/api/streams.scala
@@ -30,7 +30,7 @@ import fs2.Stream
 import sec.core._
 import sec.api.Direction._
 import sec.api.exceptions._
-import helpers.text.{snakeCaseTransformation => sct}
+import helpers.text.mkSnakeCase
 
 class StreamsSpec extends SnSpec {
 
@@ -675,7 +675,7 @@ class StreamsSpec extends SnSpec {
 
         def test(expectedRevision: StreamRevision) = {
 
-          val id = genStreamId(s"${streamPrefix}non_existing_${sct(expectedRevision.show)}_")
+          val id = genStreamId(s"${streamPrefix}non_existing_${mkSnakeCase(expectedRevision.show)}_")
 
           streams.appendToStream(id, expectedRevision, events) >>= { wr =>
             streams.readStreamForwards(id, EventNumber.Start, 2).compile.toList.map { el =>
@@ -740,7 +740,7 @@ class StreamsSpec extends SnSpec {
 
         def test(expectedRevision: StreamRevision, expectedSecondRevision: StreamRevision) = {
 
-          val rev    = sct(expectedRevision.show)
+          val rev    = mkSnakeCase(expectedRevision.show)
           val id     = genStreamId(s"${streamPrefix}multiple_writes_multiple_events_same_uuid_${rev}_")
           val event  = genEvents(1).head
           val events = Nel.of(event, List.fill(5)(event): _*)
@@ -768,7 +768,7 @@ class StreamsSpec extends SnSpec {
       "append to tombstoned stream raises" >> {
 
         def test(expectedRevision: StreamRevision) = {
-          val rev    = sct(expectedRevision.show)
+          val rev    = mkSnakeCase(expectedRevision.show)
           val id     = genStreamId(s"${streamPrefix}tombstoned_stream_${rev}_")
           val events = genEvents(1)
           val delete = streams.tombstone(id, StreamRevision.NoStream)
@@ -799,7 +799,7 @@ class StreamsSpec extends SnSpec {
 
         def test(sndExpectedRevision: StreamRevision) = {
 
-          val rev                        = sct(sndExpectedRevision.show)
+          val rev                        = mkSnakeCase(sndExpectedRevision.show)
           val id                         = genStreamId(s"${streamPrefix}existing_stream_with_${rev}_")
           def write(esr: StreamRevision) = streams.appendToStream(id, esr, genEvents(1))
 
@@ -858,7 +858,7 @@ class StreamsSpec extends SnSpec {
 
         def test(expectedRevision: StreamRevision) = {
 
-          val rev = sct(expectedRevision.show)
+          val rev = mkSnakeCase(expectedRevision.show)
           val id  = genStreamId(s"${streamPrefix}stream_exists_and_deleted_${rev}_")
 
           streams.delete(id, StreamRevision.NoStream) >>
@@ -1117,7 +1117,7 @@ class StreamsSpec extends SnSpec {
 
         def run(expectedRevision: StreamRevision) = {
 
-          val rev = sct(expectedRevision.show)
+          val rev = mkSnakeCase(expectedRevision.show)
           val id  = genStreamId(s"${streamPrefix}non_existing_stream_with_expected_revision_${rev}_")
 
           streams.delete(id, expectedRevision).void
@@ -1192,7 +1192,7 @@ class StreamsSpec extends SnSpec {
 
         def run(expectedRevision: StreamRevision) = {
 
-          val rev          = sct(expectedRevision.show)
+          val rev          = mkSnakeCase(expectedRevision.show)
           val id           = genStreamId(s"${streamPrefix}and_recreate_with_expected_revision_${rev}_")
           val beforeEvents = genEvents(1)
           val afterEvents  = genEvents(3)
@@ -1397,7 +1397,7 @@ class StreamsSpec extends SnSpec {
 
         def run(expectedRevision: StreamRevision) = {
 
-          val rev = sct(expectedRevision.show)
+          val rev = mkSnakeCase(expectedRevision.show)
           val id  = genStreamId(s"${streamPrefix}non_existing_stream_with_expected_revision_${rev}_")
 
           streams.tombstone(id, expectedRevision).void

--- a/sec-tests/src/test/scala/sec/api/filter.scala
+++ b/sec-tests/src/test/scala/sec/api/filter.scala
@@ -30,16 +30,15 @@ class EventFilterSpec extends Specification with ScalaCheck {
   "EventFilter" >> {
 
     implicit val arbKind: Arbitrary[Kind]   = Arbitrary(Gen.oneOf[Kind](ByStreamId, ByEventType))
-    implicit val arbMax: Arbitrary[Int]     = Arbitrary(Gen.posNum[Int])
     implicit val arbRegex: Arbitrary[Regex] = Arbitrary(Gen.oneOf("^ctx1__.*".r, "^[^$].*".r))
 
-    "prefix" >> prop { (k: Kind, msw: Option[Int], fst: String, rest: List[String]) =>
-      prefix(k, msw, fst, rest: _*) shouldEqual
-        EventFilter(k, msw, NonEmptyList(PrefixFilter(fst), rest.map(PrefixFilter)).asLeft)
+    "prefix" >> prop { (k: Kind, fst: String, rest: List[String]) =>
+      prefix(k, fst, rest: _*) shouldEqual
+        EventFilter(k, NonEmptyList(PrefixFilter(fst), rest.map(PrefixFilter)).asLeft)
     }
 
-    "regex" >> prop { (k: Kind, msw: Option[Int], filter: Regex) =>
-      regex(k, msw, filter.pattern.toString) shouldEqual EventFilter(k, msw, RegexFilter(filter).asRight)
+    "regex" >> prop { (k: Kind, filter: Regex) =>
+      regex(k, filter.pattern.toString) shouldEqual EventFilter(k, RegexFilter(filter).asRight)
     }
 
   }


### PR DESCRIPTION
 - remove max search window from filter.

 - add `SubscriptionFilterOptions` that has filter,
   max search window and checkpoint interval multiplier.

 - add `Checkpoint` type.

 - clean up code for `subAllFilteredPipe`.

 - bump sbt-github-actions.