### PR TITLE
sec-tests: disable retries in integration tests

### DIFF
--- a/sec-tests/src/cit/scala/sec/api/spec.scala
+++ b/sec-tests/src/cit/scala/sec/api/spec.scala
@@ -40,8 +40,6 @@ object CSpec {
     endpointFrom("SEC_CLUSTER_ES3_ADDRESS", "SEC_CIT_ES3_PORT", "127.0.0.1", 2116)
   )
 
-  final private val maxRetries = 5
-
   ///
 
   def mkClient[F[_]: ConcurrentEffect: Timer](log: Logger[F]): Resource[F, EsClient[F]] = EsClient
@@ -49,7 +47,7 @@ object CSpec {
     .withChannelShutdownAwait(0.seconds)
     .withCertificate(caPath)
     .withLogger(log)
-    .withOperationsRetryMaxAttempts(maxRetries)
+    .withOperationsRetryDisabled
     .resource
 
 }

--- a/sec-tests/src/sit/scala/sec/api/spec.scala
+++ b/sec-tests/src/sit/scala/sec/api/spec.scala
@@ -50,7 +50,6 @@ object SnSpec {
   final private val authority   = sys.env.getOrElse("SEC_SIT_AUTHORITY", "es.sec.local")
   final private val address     = sys.env.getOrElse("SEC_SIT_HOST_ADDRESS", "127.0.0.1")
   final private val port        = sys.env.get("SEC_SIT_HOST_PORT").flatMap(_.toIntOption).getOrElse(2113)
-  final private val maxRetries  = 5
 
   ///
 
@@ -60,7 +59,7 @@ object SnSpec {
     .withCertificate(certPath)
     .withChannelShutdownAwait(0.seconds)
     .withLogger(log)
-    .withOperationsRetryMaxAttempts(maxRetries)
+    .withOperationsRetryDisabled
     .resource
 
 }


### PR DESCRIPTION
 - tests should pass regardless of retries enabled.
   For now, let errors surface.