### PR TITLE
core: remove channel closed exception handling

### DIFF
--- a/sec-tests/src/test/scala/sec/api/grpc/convert.scala
+++ b/sec-tests/src/test/scala/sec/api/grpc/convert.scala
@@ -18,7 +18,6 @@ package sec
 package api
 package grpc
 
-import java.nio.channels.ClosedChannelException
 import cats.syntax.all._
 import io.grpc.{Metadata, Status, StatusRuntimeException}
 import org.specs2._
@@ -187,12 +186,8 @@ class ConvertSpec extends mutable.Specification {
 
     /// From Status Codes & Causes
 
-    convertToEs(Status.UNAVAILABLE.asRuntimeException()) should beSome(
-      ServerUnavailable("Server Unavailable: No description specified.")
-    )
-
-    convertToEs(Status.UNKNOWN.withCause(new ClosedChannelException()).asRuntimeException()) should beSome(
-      ServerUnavailable("Server Unavailable: Channel closed.")
+    convertToEs(Status.UNAVAILABLE.withDescription("Oops").asRuntimeException()) should beSome(
+      ServerUnavailable("UNAVAILABLE: Oops")
     )
 
   }


### PR DESCRIPTION
 - remove special handling of `ChannelClosedException` as
   grpc-java is fixed wrt. returning `UNVAILABLE` instead
   of `UNKNOWN` when TCP close during TLS handshake.

 - see: https://github.com/grpc/grpc-java/commit/ec0d01d7a40af3d7f7b5e2f4d4c549bd27701f4e