### PR TITLE
ci+deps: use custom ci image until upstream is fixed + specs2 bump

### DIFF
--- a/.docker/cluster.ci.yml
+++ b/.docker/cluster.ci.yml
@@ -6,7 +6,7 @@ x-common-variables: &common-variables
 services:
 
   es1:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:
@@ -24,7 +24,7 @@ services:
       - cert-gen
 
   es2:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:
@@ -42,7 +42,7 @@ services:
       - cert-gen
 
   es3:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:

--- a/.docker/single-node.ci.yml
+++ b/.docker/single-node.ci.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   es:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:

--- a/core/src/main/scala/sec/api/mapping/implicits.scala
+++ b/core/src/main/scala/sec/api/mapping/implicits.scala
@@ -35,8 +35,14 @@ private[sec] object implicits {
   ///
 
   implicit final class OptionOps[A](private val o: Option[A]) extends AnyVal {
-    def require[F[_]: ErrorA](value: String): F[A] =
-      o.toRight(ProtoResultError(s"Required value $value missing or invalid.")).liftTo[F]
+
+    def require[F[_]: ErrorA](value: String): F[A] = require[F](value, None)
+
+    def require[F[_]: ErrorA](value: String, details: Option[String]) = {
+      def extra = details.map(d => s" $d").getOrElse("")
+      def msg   = s"Required value $value missing or invalid.$extra"
+      o.toRight(ProtoResultError(msg)).liftTo[F]
+    }
   }
 
 }

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -249,7 +249,7 @@ private[sec] object streams {
     def reqConfirmation[F[_]: ErrorA](rr: ReadResp): F[SubscriptionConfirmation] =
       rr.content.confirmation
         .map(_.subscriptionId)
-        .require[F]("SubscriptionConfirmation")
+        .require[F]("SubscriptionConfirmation", details = s"Got ${rr.content} instead".some)
         .map(SubscriptionConfirmation)
 
     def mkEvent[F[_]: ErrorM](re: ReadResp.ReadEvent): F[Option[Event]] =

--- a/core/src/main/scala/sec/id.scala
+++ b/core/src/main/scala/sec/id.scala
@@ -17,7 +17,7 @@
 package sec
 
 import cats.syntax.all._
-import cats.{ApplicativeError, Eq, Show}
+import cats.{Eq, Show}
 import sec.utilities.{guardNonEmpty, guardNotStartsWith}
 
 //======================================================================================================================
@@ -40,11 +40,11 @@ object StreamId {
   sealed abstract case class System(name: String) extends SystemId
   sealed abstract case class Normal(name: String) extends NormalId
 
-  def apply[F[_]](name: String)(implicit F: ApplicativeError[F, Throwable]): F[Id] =
-    from(name).leftMap(StreamIdError).liftTo[F]
-
-  def from(name: String): Attempt[Id] =
+  def apply(name: String): Attempt[Id] =
     guardNonEmptyName(name) >>= guardNotStartsWith(metadataPrefix) >>= stringToId
+
+  def of[F[_]: ErrorA](name: String): F[Id] =
+    StreamId(name).leftMap(StreamIdError).liftTo[F]
 
   final case class StreamIdError(msg: String) extends RuntimeException(msg)
 

--- a/core/src/main/scala/sec/metadata.scala
+++ b/core/src/main/scala/sec/metadata.scala
@@ -121,7 +121,7 @@ object MaxAge {
     if (maxAge < 1.second) s"maxAge must be >= 1 second, it was $maxAge.".asLeft
     else new MaxAge(maxAge) {}.asRight
 
-  def lift[F[_]: ErrorA](maxAge: FiniteDuration): F[MaxAge] =
+  def of[F[_]: ErrorA](maxAge: FiniteDuration): F[MaxAge] =
     MaxAge(maxAge).orFail[F](InvalidMaxAge)
 
   implicit val showForMaxAge: Show[MaxAge] = Show.show(_.value.toString())
@@ -139,7 +139,7 @@ object MaxCount {
     if (maxCount < 1) s"max count must be >= 1, it was $maxCount.".asLeft
     else new MaxCount(maxCount) {}.asRight
 
-  def lift[F[_]: ErrorA](maxCount: Int): F[MaxCount] =
+  def of[F[_]: ErrorA](maxCount: Int): F[MaxCount] =
     MaxCount(maxCount).orFail[F](InvalidMaxCount)
 
   implicit val showForMaxCount: Show[MaxCount] = Show.show { mc =>
@@ -160,7 +160,7 @@ object CacheControl {
     if (cacheControl < 1.second) s"cache control must be >= 1, it was $cacheControl.".asLeft
     else new CacheControl(cacheControl) {}.asRight
 
-  def lift[F[_]: ErrorA](cacheControl: FiniteDuration): F[CacheControl] =
+  def of[F[_]: ErrorA](cacheControl: FiniteDuration): F[CacheControl] =
     CacheControl(cacheControl).orFail[F](InvalidCacheControl)
 
   implicit val showForCacheControl: Show[CacheControl] = Show.show(_.value.toString())

--- a/core/src/main/scala/sec/version.scala
+++ b/core/src/main/scala/sec/version.scala
@@ -54,7 +54,7 @@ object EventNumber {
     def apply(value: Long): Attempt[Exact] =
       Either.cond(value >= 0L, create(value), s"value must be >= 0, but is $value")
 
-    def lift[F[_]: ErrorA](value: Long): F[Exact] =
+    def of[F[_]: ErrorA](value: Long): F[Exact] =
       Exact(value).leftMap(InvalidExact).liftTo[F]
 
     ///

--- a/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
@@ -46,7 +46,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     setMaxAgeF(id, expectedRevision, age, uc.some)
 
   private def setMaxAgeF(id: Id, er: StreamRevision, age: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-    MaxAge.lift[F](age) >>= (ms.setMaxAge(id, er, _, uc))
+    MaxAge.of[F](age) >>= (ms.setMaxAge(id, er, _, uc))
 
   def unsetMaxAge(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
     ms.unsetMaxAge(id, expectedRevision, None)
@@ -61,7 +61,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     setMaxCountF(id, expectedRevision, count, uc.some)
 
   private def setMaxCountF(id: Id, er: StreamRevision, count: Int, uc: Option[UserCredentials]): F[WriteResult] =
-    MaxCount.lift[F](count) >>= (ms.setMaxCount(id, er, _, uc))
+    MaxCount.of[F](count) >>= (ms.setMaxCount(id, er, _, uc))
 
   def unsetMaxCount(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
     ms.unsetMaxCount(id, expectedRevision, None)
@@ -86,7 +86,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     cc: FiniteDuration,
     uc: Option[UserCredentials]
   ): F[WriteResult] =
-    CacheControl.lift[F](cc) >>= (ms.setCacheControl(id, er, _, uc))
+    CacheControl.of[F](cc) >>= (ms.setCacheControl(id, er, _, uc))
 
   def unsetCacheControl(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
     ms.unsetCacheControl(id, expectedRevision, None)
@@ -115,7 +115,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     setTruncateBeforeF(id, expectedRevision, truncateBefore, uc.some)
 
   private def setTruncateBeforeF(id: Id, er: StreamRevision, tb: Long, uc: Option[UserCredentials]): F[WriteResult] =
-    EventNumber.Exact.lift[F](tb) >>= (ms.setTruncateBefore(id, er, _, uc))
+    EventNumber.Exact.of[F](tb) >>= (ms.setTruncateBefore(id, er, _, uc))
 
   def unsetTruncateBefore(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
     ms.unsetTruncateBefore(id, expectedRevision, None)

--- a/fs2/src/main/scala-3/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/metastreams.scala
@@ -40,7 +40,7 @@ trait MetaStreamsSyntax {
       setMaxAgeF(id, expectedRevision, age, uc.some)
       
     private def setMaxAgeF(id: Id, er: StreamRevision, m: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-      MaxAge.lift[F](m) >>= (ms.setMaxAge(id, er, _, uc))
+      MaxAge.of[F](m) >>= (ms.setMaxAge(id, er, _, uc))
 
     def unsetMaxAge(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
       ms.unsetMaxAge(id, expectedRevision, None)
@@ -55,7 +55,7 @@ trait MetaStreamsSyntax {
       setMaxCountF(id, expectedRevision, count, uc.some)
       
     private def setMaxCountF(id: Id, er: StreamRevision, count: Int, uc: Option[UserCredentials]): F[WriteResult] =
-      MaxCount.lift[F](count) >>= (ms.setMaxCount(id, er, _, uc))
+      MaxCount.of[F](count) >>= (ms.setMaxCount(id, er, _, uc))
 
     def unsetMaxCount(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
       ms.unsetMaxCount(id, expectedRevision, None)
@@ -70,7 +70,7 @@ trait MetaStreamsSyntax {
       setCacheControlF(id, expectedRevision, cacheControl, uc.some)
       
     private def setCacheControlF(id: Id, er: StreamRevision, cacheControl: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-      CacheControl.lift[F](cacheControl) >>= (ms.setCacheControl(id, er, _, uc))
+      CacheControl.of[F](cacheControl) >>= (ms.setCacheControl(id, er, _, uc))
 
     def unsetCacheControl(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
       ms.unsetCacheControl(id, expectedRevision, None)
@@ -94,7 +94,7 @@ trait MetaStreamsSyntax {
       setTruncateBeforeF(id, expectedRevision, truncateBefore, uc.some)
       
     private def setTruncateBeforeF(id: Id, er: StreamRevision, tb: Long, uc: Option[UserCredentials]): F[WriteResult] =
-      EventNumber.Exact.lift[F](tb) >>= (ms.setTruncateBefore(id, er, _, uc))
+      EventNumber.Exact.of[F](tb) >>= (ms.setTruncateBefore(id, er, _, uc))
 
     def unsetTruncateBefore(id: Id, expectedRevision: StreamRevision): F[WriteResult] =
       ms.unsetTruncateBefore(id, expectedRevision, None)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     val grpc             = org.lyranthe.fs2_grpc.buildinfo.BuildInfo.grpcVersion
     val tcnative         = "2.0.30.Final"
     val disciplineSpecs2 = "1.1.0"
-    val specs2           = "4.10.4"
+    val specs2           = "4.10.3"
     val catsEffectSpecs2 = "0.4.1"
 
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     val grpc             = org.lyranthe.fs2_grpc.buildinfo.BuildInfo.grpcVersion
     val tcnative         = "2.0.30.Final"
     val disciplineSpecs2 = "1.1.0"
-    val specs2           = "4.10.3"
+    val specs2           = "4.10.4"
     val catsEffectSpecs2 = "0.4.1"
 
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("ch.epfl.lamp"              % "sbt-dotty"          % "0.4.2")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"       % "0.1.13")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"       % "0.1.14")
 addSbtPlugin("com.codecommit"            % "sbt-github-actions" % "0.9.3")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"         % "5.6.0")
 addSbtPlugin("com.geirsson"              % "sbt-ci-release"     % "1.5.3")

--- a/tests/src/sit/scala/sec/api/streams.scala
+++ b/tests/src/sit/scala/sec/api/streams.scala
@@ -71,7 +71,7 @@ class StreamsSuite extends SnSpec {
           val run       = subscribe(exclusiveFrom, Set(s1, s2).contains).concurrently(writeBoth)
 
           run.take(count).compile.toList.map { events =>
-            events.size shouldEqual count
+            events.size.toLong shouldEqual count
             events.filter(_.streamId == s1).map(_.eventData).toNel should beSome(s1Events)
             events.filter(_.streamId == s2).map(_.eventData).toNel should beSome(s2Events)
 

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -571,7 +571,7 @@ class StreamsMappingSpec extends mutable.Specification {
     "reqConfirmation" >> {
 
       reqConfirmation[ErrorOr](s.ReadResp()) shouldEqual
-        ProtoResultError("Required value SubscriptionConfirmation missing or invalid.").asLeft
+        ProtoResultError("Required value SubscriptionConfirmation missing or invalid. Got Empty instead").asLeft
 
       reqConfirmation[ErrorOr](s.ReadResp().withConfirmation(s.ReadResp.SubscriptionConfirmation("id"))) shouldEqual
         SubscriptionConfirmation("id").asRight

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -144,7 +144,7 @@ class StreamsMappingSpec extends mutable.Specification {
     "mkSubscribeToStreamReq" >> {
       import EventNumber._
 
-      val sid = StreamId.from("abc").unsafe
+      val sid = StreamId("abc").unsafe
 
       def test(exclusiveFrom: Option[EventNumber], resolveLinkTos: Boolean) =
         mkSubscribeToStreamReq(sid, exclusiveFrom, resolveLinkTos) shouldEqual s
@@ -198,7 +198,7 @@ class StreamsMappingSpec extends mutable.Specification {
 
     "mkReadStreamReq" >> {
 
-      val sid = sec.StreamId.from("abc").unsafe
+      val sid = sec.StreamId("abc").unsafe
 
       def test(rd: Direction, from: EventNumber, count: Long, rlt: Boolean) =
         mkReadStreamReq(sid, from, rd, count, rlt) shouldEqual s
@@ -250,7 +250,7 @@ class StreamsMappingSpec extends mutable.Specification {
     "mkDeleteReq" >> {
 
       import s.DeleteReq.Options.ExpectedStreamRevision
-      val sid = sec.StreamId.from("abc").unsafe
+      val sid = sec.StreamId("abc").unsafe
 
       def test(sr: StreamRevision, esr: ExpectedStreamRevision) =
         mkDeleteReq(sid, sr) shouldEqual
@@ -265,7 +265,7 @@ class StreamsMappingSpec extends mutable.Specification {
     "mkTombstoneReq" >> {
 
       import s.TombstoneReq.Options.ExpectedStreamRevision
-      val sid = sec.StreamId.from("abc").unsafe
+      val sid = sec.StreamId("abc").unsafe
 
       def test(sr: StreamRevision, esr: ExpectedStreamRevision) =
         mkTombstoneReq(sid, sr) shouldEqual
@@ -280,7 +280,7 @@ class StreamsMappingSpec extends mutable.Specification {
     "mkAppendHeaderReq" >> {
 
       import s.AppendReq.Options.ExpectedStreamRevision
-      val sid = sec.StreamId.from("abc").unsafe
+      val sid = sec.StreamId("abc").unsafe
 
       def test(sr: StreamRevision, esr: ExpectedStreamRevision) =
         mkAppendHeaderReq(sid, sr) shouldEqual
@@ -391,7 +391,7 @@ class StreamsMappingSpec extends mutable.Specification {
         .withMetadata(linkMetadata)
 
       val eventRecord = EventRecord(
-        sec.StreamId.from(streamId).unsafe,
+        sec.StreamId(streamId).unsafe,
         sec.EventNumber.exact(revision),
         sec.Position.exact(commit, prepare),
         sec.EventData(sec.EventType(eventType).unsafe, JUUID.fromString(id), data, customMeta, sec.ContentType.Json),
@@ -399,7 +399,7 @@ class StreamsMappingSpec extends mutable.Specification {
       )
 
       val linkRecord = sec.EventRecord(
-        sec.StreamId.from(linkStreamId).unsafe,
+        sec.StreamId(linkStreamId).unsafe,
         sec.EventNumber.exact(linkRevision),
         sec.Position.exact(linkCommit, linkPrepare),
         sec.EventData(sec.EventType.LinkTo, JUUID.fromString(linkId), linkData, linkCustomMeta, sec.ContentType.Binary),
@@ -459,7 +459,7 @@ class StreamsMappingSpec extends mutable.Specification {
           .withMetadata(metadata)
 
       val eventRecord = sec.EventRecord(
-        sec.StreamId.from(streamId).unsafe,
+        sec.StreamId(streamId).unsafe,
         sec.EventNumber.exact(revision),
         sec.Position.exact(commit, prepare),
         sec.EventData(sec.EventType(eventType).unsafe, JUUID.fromString(id), data, customMeta, sec.ContentType.Binary),
@@ -592,7 +592,7 @@ class StreamsMappingSpec extends mutable.Specification {
       import s.AppendResp.WrongExpectedVersion.ExpectedRevisionOption
       import s.AppendResp.WrongExpectedVersion.CurrentRevisionOption
 
-      val sid: StreamId.Id                           = sec.StreamId.from("abc").unsafe
+      val sid: StreamId.Id                           = sec.StreamId("abc").unsafe
       val test: s.AppendResp => ErrorOr[WriteResult] = mkWriteResult[ErrorOr](sid, _)
 
       val successRevOne   = Success().withCurrentRevision(1L).withPosition(s.AppendResp.Position(1L, 1L))

--- a/tests/src/test/scala/sec/event.scala
+++ b/tests/src/test/scala/sec/event.scala
@@ -19,9 +19,11 @@ package sec
 import java.{util => ju}
 import java.time.ZonedDateTime
 import java.util.UUID
+
 import cats.syntax.all._
 import scodec.bits.ByteVector
 import org.specs2.mutable.Specification
+import sec.EventType.InvalidEventType
 import sec.arbitraries._
 import sec.helpers.text.encodeToBV
 
@@ -33,7 +35,7 @@ class EventSpec extends Specification {
     ByteVector.encodeUtf8(data).leftMap(_.getMessage).unsafe
 
   val er: EventRecord = sec.EventRecord(
-    StreamId.from("abc-1234").unsafe,
+    StreamId("abc-1234").unsafe,
     EventNumber.exact(5L),
     sampleOf[Position.Exact],
     EventData("et", sampleOf[ju.UUID], bv("abc"), ContentType.Binary).unsafe,
@@ -130,6 +132,12 @@ class EventTypeSpec extends Specification {
     EventType("") should beLeft("Event type name cannot be empty")
     EventType("$users") should beLeft("value must not start with $, but is $users")
     EventType("users") should beRight(EventType.userDefined("users").unsafe)
+  }
+
+  "of" >> {
+    EventType.of[ErrorOr]("") should beLeft(InvalidEventType("Event type name cannot be empty"))
+    EventType.of[ErrorOr]("$users") should beLeft(InvalidEventType("value must not start with $, but is $users"))
+    EventType.of[ErrorOr]("users") should beRight(EventType.userDefined("users").unsafe)
   }
 
   "eventTypeToString" >> {

--- a/tests/src/test/scala/sec/id.scala
+++ b/tests/src/test/scala/sec/id.scala
@@ -27,38 +27,38 @@ class StreamIdSpec extends Specification with Discipline {
 
   import StreamId.{systemStreams => ss}
 
-  val normalId = StreamId.normal("normal").unsafe
-  val systemId = StreamId.system("system").unsafe
-
-  "from" >> {
-    StreamId.from("") should beLeft("name cannot be empty")
-    StreamId.from("$$meta") should beLeft("value must not start with $$, but is $$meta")
-    StreamId.from("$users") shouldEqual StreamId.system("users")
-    StreamId.from("users") shouldEqual StreamId.normal("users")
-    StreamId.from(ss.All) shouldEqual StreamId.All.asRight
-    StreamId.from(ss.Settings) shouldEqual StreamId.Settings.asRight
-    StreamId.from(ss.Stats) shouldEqual StreamId.Stats.asRight
-    StreamId.from(ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
-    StreamId.from(ss.Streams) shouldEqual StreamId.Streams.asRight
-  }
+  val normalId: StreamId.Normal = StreamId.normal("normal").unsafe
+  val systemId: StreamId.System = StreamId.system("system").unsafe
 
   "apply" >> {
+    StreamId("") should beLeft("name cannot be empty")
+    StreamId("$$meta") should beLeft("value must not start with $$, but is $$meta")
+    StreamId("$users") shouldEqual StreamId.system("users")
+    StreamId("users") shouldEqual StreamId.normal("users")
+    StreamId(ss.All) shouldEqual StreamId.All.asRight
+    StreamId(ss.Settings) shouldEqual StreamId.Settings.asRight
+    StreamId(ss.Stats) shouldEqual StreamId.Stats.asRight
+    StreamId(ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
+    StreamId(ss.Streams) shouldEqual StreamId.Streams.asRight
+  }
 
-    StreamId[ErrorOr]("") should beLike { case Left(StreamId.StreamIdError("name cannot be empty")) =>
+  "of" >> {
+
+    StreamId.of[ErrorOr]("") should beLike { case Left(StreamId.StreamIdError("name cannot be empty")) =>
       ok
     }
 
-    StreamId[ErrorOr]("$$m") should beLike {
+    StreamId.of[ErrorOr]("$$m") should beLike {
       case Left(StreamId.StreamIdError("value must not start with $$, but is $$m")) => ok
     }
 
-    StreamId[ErrorOr]("$users") shouldEqual StreamId.system("users")
-    StreamId[ErrorOr]("users") shouldEqual StreamId.normal("users")
-    StreamId[ErrorOr](ss.All) shouldEqual StreamId.All.asRight
-    StreamId[ErrorOr](ss.Settings) shouldEqual StreamId.Settings.asRight
-    StreamId[ErrorOr](ss.Stats) shouldEqual StreamId.Stats.asRight
-    StreamId[ErrorOr](ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
-    StreamId[ErrorOr](ss.Streams) shouldEqual StreamId.Streams.asRight
+    StreamId.of[ErrorOr]("$users") shouldEqual StreamId.system("users")
+    StreamId.of[ErrorOr]("users") shouldEqual StreamId.normal("users")
+    StreamId.of[ErrorOr](ss.All) shouldEqual StreamId.All.asRight
+    StreamId.of[ErrorOr](ss.Settings) shouldEqual StreamId.Settings.asRight
+    StreamId.of[ErrorOr](ss.Stats) shouldEqual StreamId.Stats.asRight
+    StreamId.of[ErrorOr](ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
+    StreamId.of[ErrorOr](ss.Streams) shouldEqual StreamId.Streams.asRight
   }
 
   "streamIdToString" >> {

--- a/tests/src/test/scala/sec/version.scala
+++ b/tests/src/test/scala/sec/version.scala
@@ -60,9 +60,9 @@ class VersionSpec extends Specification with Discipline {
       Exact(0L) should beRight(EventNumber.exact(0L))
     }
 
-    "Exact.lift" >> {
-      Exact.lift[ErrorOr](-1L) should beLeft(InvalidExact("value must be >= 0, but is -1"))
-      Exact.lift[ErrorOr](0L) should beRight(EventNumber.exact(0L))
+    "Exact.of" >> {
+      Exact.of[ErrorOr](-1L) should beLeft(InvalidExact("value must be >= 0, but is -1"))
+      Exact.of[ErrorOr](0L) should beRight(EventNumber.exact(0L))
     }
 
     "Show" >> {


### PR DESCRIPTION
 - specs2 bump causes a test to fail where an int is
   compared to a long.

 - esdb image is temporarily based on a branch by thefringeningja
   that seems to fix one-off errors in subscriptions to streams
   that do not exist.