### PR TITLE
ci+deps: use custom ci image + specs2 bump

### DIFF
--- a/.docker/cluster.ci.yml
+++ b/.docker/cluster.ci.yml
@@ -6,7 +6,7 @@ x-common-variables: &common-variables
 services:
 
   es1:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:
@@ -24,7 +24,7 @@ services:
       - cert-gen
 
   es2:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:
@@ -42,7 +42,7 @@ services:
       - cert-gen
 
   es3:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:

--- a/.docker/single-node.ci.yml
+++ b/.docker/single-node.ci.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   es:
-    image: eventstore/eventstore:20.6.1-bionic
+    image: quay.io/ahjohannessen/es-v6:channels
     env_file:
       - shared.env
     environment:

--- a/core/src/main/scala/sec/api/mapping/implicits.scala
+++ b/core/src/main/scala/sec/api/mapping/implicits.scala
@@ -35,8 +35,14 @@ private[sec] object implicits {
   ///
 
   implicit final class OptionOps[A](private val o: Option[A]) extends AnyVal {
-    def require[F[_]: ErrorA](value: String): F[A] =
-      o.toRight(ProtoResultError(s"Required value $value missing or invalid.")).liftTo[F]
+
+    def require[F[_]: ErrorA](value: String): F[A] = require[F](value, None)
+
+    def require[F[_]: ErrorA](value: String, details: Option[String]) = {
+      def extra = details.map(d => s" $d").getOrElse("")
+      def msg   = s"Required value $value missing or invalid.$extra"
+      o.toRight(ProtoResultError(msg)).liftTo[F]
+    }
   }
 
 }

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -249,7 +249,7 @@ private[sec] object streams {
     def reqConfirmation[F[_]: ErrorA](rr: ReadResp): F[SubscriptionConfirmation] =
       rr.content.confirmation
         .map(_.subscriptionId)
-        .require[F]("SubscriptionConfirmation")
+        .require[F]("SubscriptionConfirmation", details = s"Got ${rr.content} instead".some)
         .map(SubscriptionConfirmation)
 
     def mkEvent[F[_]: ErrorM](re: ReadResp.ReadEvent): F[Option[Event]] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     val grpc             = org.lyranthe.fs2_grpc.buildinfo.BuildInfo.grpcVersion
     val tcnative         = "2.0.30.Final"
     val disciplineSpecs2 = "1.1.0"
-    val specs2           = "4.10.3"
+    val specs2           = "4.10.4"
     val catsEffectSpecs2 = "0.4.1"
 
   }

--- a/tests/src/sit/scala/sec/api/streams.scala
+++ b/tests/src/sit/scala/sec/api/streams.scala
@@ -71,7 +71,7 @@ class StreamsSuite extends SnSpec {
           val run       = subscribe(exclusiveFrom, Set(s1, s2).contains).concurrently(writeBoth)
 
           run.take(count).compile.toList.map { events =>
-            events.size shouldEqual count
+            events.size.toLong shouldEqual count
             events.filter(_.streamId == s1).map(_.eventData).toNel should beSome(s1Events)
             events.filter(_.streamId == s2).map(_.eventData).toNel should beSome(s2Events)
 

--- a/tests/src/test/scala/sec/api/mapping/implicits.scala
+++ b/tests/src/test/scala/sec/api/mapping/implicits.scala
@@ -31,6 +31,10 @@ class ImplicitsSpec extends mutable.Specification {
       case Left(ProtoResultError("Required value test missing or invalid.")) => ok
     }
 
+    Option.empty[Int].require[ErrorOr]("test", details = "Oh Noes!".some) should beLike {
+      case Left(ProtoResultError("Required value test missing or invalid. Oh Noes!")) => ok
+    }
+
     Option(1).require[ErrorOr]("test") should beRight(1)
   }
 

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -571,7 +571,7 @@ class StreamsMappingSpec extends mutable.Specification {
     "reqConfirmation" >> {
 
       reqConfirmation[ErrorOr](s.ReadResp()) shouldEqual
-        ProtoResultError("Required value SubscriptionConfirmation missing or invalid.").asLeft
+        ProtoResultError("Required value SubscriptionConfirmation missing or invalid. Got Empty instead").asLeft
 
       reqConfirmation[ErrorOr](s.ReadResp().withConfirmation(s.ReadResp.SubscriptionConfirmation("id"))) shouldEqual
         SubscriptionConfirmation("id").asRight


### PR DESCRIPTION
 - specs2 bump causes a test to fail where an int is compared
   to a long.

 - esdb image is temporarily based on a branch by thefringeningja
   that fixes one-off errors in subscriptions to streams.

 - add option to add extra details in `OptionOps.require` in
   mapping/implicits.scala.

 - change `reqConfirmation` to provide more details when failing.