### PR TITLE
core/api: use either for input validation

### DIFF
--- a/core/src/main/scala/sec/api/gossip.scala
+++ b/core/src/main/scala/sec/api/gossip.scala
@@ -53,7 +53,7 @@ object MemberInfo {
 
   private[sec] def mkShow(padTo: Int): Show[MemberInfo] = Show.show { mi =>
 
-    val alive    = s"${mi.isAlive.fold("✔", "✕")}"
+    val alive    = s"${if (mi.isAlive) "✔" else "✕"}"
     val state    = s"${mi.state.show.padTo(padTo, ' ')}"
     val endpoint = s"${mi.httpEndpoint.show}"
     val ts       = s"${mi.timestamp.truncatedTo(SECONDS)}"

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -223,11 +223,11 @@ private[sec] object streams {
 
   object incoming {
 
-    def mkCheckpoint[F[_]: ErrorA](c: ReadResp.Checkpoint): F[Checkpoint] = LogPosition
-      .Exact(c.commitPosition, c.preparePosition)
-      .map(Checkpoint)
-      .leftMap(error => ProtoResultError(s"Invalid position for Checkpoint: $error"))
-      .liftTo[F]
+    def mkCheckpoint[F[_]: ErrorA](c: ReadResp.Checkpoint): F[Checkpoint] =
+      LogPosition(c.commitPosition, c.preparePosition)
+        .map(Checkpoint)
+        .leftMap(error => ProtoResultError(s"Invalid position for Checkpoint: ${error.msg}"))
+        .liftTo[F]
 
     def mkCheckpointOrEvent[F[_]: ErrorM](re: ReadResp): F[Option[Either[Checkpoint, Event]]] = {
 

--- a/core/src/main/scala/sec/error.scala
+++ b/core/src/main/scala/sec/error.scala
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import cats.{ApplicativeError, MonadError}
+package sec
 
-package object sec {
+import scala.util.control.NoStackTrace
 
-  private[sec] type ErrorM[F[_]] = MonadError[F, Throwable]
-  private[sec] type ErrorA[F[_]] = ApplicativeError[F, Throwable]
-  private[sec] type Attempt[T]   = Either[String, T]
-  private[sec] type ErrorOr[T]   = Either[Throwable, T]
-
-}
+sealed abstract class ValidationError(msg: String) extends RuntimeException(msg) with NoStackTrace
+final case class InvalidInput(msg: String)         extends ValidationError(msg)

--- a/core/src/main/scala/sec/id.scala
+++ b/core/src/main/scala/sec/id.scala
@@ -40,13 +40,8 @@ object StreamId {
   sealed abstract case class System(name: String) extends SystemId
   sealed abstract case class Normal(name: String) extends NormalId
 
-  def apply(name: String): Attempt[Id] =
-    guardNonEmptyName(name) >>= guardNotStartsWith(metadataPrefix) >>= stringToId
-
-  def of[F[_]: ErrorA](name: String): F[Id] =
-    StreamId(name).leftMap(StreamIdError).liftTo[F]
-
-  final case class StreamIdError(msg: String) extends RuntimeException(msg)
+  def apply(name: String): Either[InvalidInput, Id] =
+    (guardNonEmptyName(name) >>= guardNotStartsWith(metadataPrefix) >>= stringToId).leftMap(InvalidInput)
 
   ///
 

--- a/core/src/main/scala/sec/utilities.scala
+++ b/core/src/main/scala/sec/utilities.scala
@@ -32,19 +32,6 @@ private[sec] object utilities {
 
 //======================================================================================================================
 
-  final class BooleanOps(val b: Boolean) extends AnyVal {
-    def fold[A](t: => A, f: => A): A = if (b) t else f
-  }
-
-//======================================================================================================================
-
-  final class AttemptOps[A](val inner: Attempt[A]) extends AnyVal {
-    def unsafe: A                                           = inner.leftMap(require(false, _)).toOption.get
-    def orFail[F[_]: ErrorA](fn: String => Throwable): F[A] = inner.leftMap(fn(_)).liftTo[F]
-  }
-
-//======================================================================================================================
-
   def format(duration: Duration): String = {
 
     def chooseUnit(fd: FiniteDuration): TimeUnit = {

--- a/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
@@ -46,7 +46,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     setMaxAgeF(id, expectedState, age, uc.some)
 
   private def setMaxAgeF(id: Id, er: StreamState, age: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-    MaxAge.of[F](age) >>= (ms.setMaxAge(id, er, _, uc))
+    MaxAge(age).liftTo[F] >>= (ms.setMaxAge(id, er, _, uc))
 
   def unsetMaxAge(id: Id, expectedState: StreamState): F[WriteResult] =
     ms.unsetMaxAge(id, expectedState, None)
@@ -61,7 +61,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     setMaxCountF(id, expectedState, count, uc.some)
 
   private def setMaxCountF(id: Id, er: StreamState, count: Int, uc: Option[UserCredentials]): F[WriteResult] =
-    MaxCount.of[F](count) >>= (ms.setMaxCount(id, er, _, uc))
+    MaxCount(count).liftTo[F] >>= (ms.setMaxCount(id, er, _, uc))
 
   def unsetMaxCount(id: Id, expectedState: StreamState): F[WriteResult] =
     ms.unsetMaxCount(id, expectedState, None)
@@ -86,7 +86,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     cc: FiniteDuration,
     uc: Option[UserCredentials]
   ): F[WriteResult] =
-    CacheControl.of[F](cc) >>= (ms.setCacheControl(id, er, _, uc))
+    CacheControl(cc).liftTo[F] >>= (ms.setCacheControl(id, er, _, uc))
 
   def unsetCacheControl(id: Id, expectedState: StreamState): F[WriteResult] =
     ms.unsetCacheControl(id, expectedState, None)
@@ -115,7 +115,7 @@ final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
     setTruncateBeforeF(id, expectedState, truncateBefore, uc.some)
 
   private def setTruncateBeforeF(id: Id, er: StreamState, tb: Long, uc: Option[UserCredentials]): F[WriteResult] =
-    StreamPosition.Exact.of[F](tb) >>= (ms.setTruncateBefore(id, er, _, uc))
+    StreamPosition(tb).liftTo[F] >>= (ms.setTruncateBefore(id, er, _, uc))
 
   def unsetTruncateBefore(id: Id, expectedState: StreamState): F[WriteResult] =
     ms.unsetTruncateBefore(id, expectedState, None)

--- a/fs2/src/main/scala-3/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/metastreams.scala
@@ -40,7 +40,7 @@ trait MetaStreamsSyntax {
       setMaxAgeF(id, expectedState, age, uc.some)
       
     private def setMaxAgeF(id: Id, er: StreamState, m: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-      MaxAge.of[F](m) >>= (ms.setMaxAge(id, er, _, uc))
+      MaxAge(m).liftTo[F] >>= (ms.setMaxAge(id, er, _, uc))
 
     def unsetMaxAge(id: Id, expectedState: StreamState): F[WriteResult] =
       ms.unsetMaxAge(id, expectedState, None)
@@ -55,7 +55,7 @@ trait MetaStreamsSyntax {
       setMaxCountF(id, expectedState, count, uc.some)
       
     private def setMaxCountF(id: Id, er: StreamState, count: Int, uc: Option[UserCredentials]): F[WriteResult] =
-      MaxCount.of[F](count) >>= (ms.setMaxCount(id, er, _, uc))
+      MaxCount(count).liftTo[F] >>= (ms.setMaxCount(id, er, _, uc))
 
     def unsetMaxCount(id: Id, expectedState: StreamState): F[WriteResult] =
       ms.unsetMaxCount(id, expectedState, None)
@@ -70,7 +70,7 @@ trait MetaStreamsSyntax {
       setCacheControlF(id, expectedState, cacheControl, uc.some)
       
     private def setCacheControlF(id: Id, er: StreamState, cacheControl: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-      CacheControl.of[F](cacheControl) >>= (ms.setCacheControl(id, er, _, uc))
+      CacheControl(cacheControl).liftTo[F] >>= (ms.setCacheControl(id, er, _, uc))
 
     def unsetCacheControl(id: Id, expectedState: StreamState): F[WriteResult] =
       ms.unsetCacheControl(id, expectedState, None)
@@ -94,7 +94,7 @@ trait MetaStreamsSyntax {
       setTruncateBeforeF(id, expectedState, truncateBefore, uc.some)
       
     private def setTruncateBeforeF(id: Id, er: StreamState, tb: Long, uc: Option[UserCredentials]): F[WriteResult] =
-      StreamPosition.Exact.of[F](tb) >>= (ms.setTruncateBefore(id, er, _, uc))
+      StreamPosition(tb).liftTo[F] >>= (ms.setTruncateBefore(id, er, _, uc))
 
     def unsetTruncateBefore(id: Id, expectedState: StreamState): F[WriteResult] =
       ms.unsetTruncateBefore(id, expectedState, None)

--- a/fs2/src/main/scala/sec/api/opts.scala
+++ b/fs2/src/main/scala/sec/api/opts.scala
@@ -36,7 +36,7 @@ private[sec] object Opts {
   implicit final class OptsOps[F[_]](val opts: Opts[F]) extends AnyVal {
 
     def run[A](fa: F[A], opName: String)(implicit F: Concurrent[F], T: Timer[F]): F[A] =
-      opts.retryEnabled.fold(retry[F, A](fa, opName, opts.retryConfig, opts.log)(opts.retryOn), fa)
+      if (opts.retryEnabled) retry[F, A](fa, opName, opts.retryConfig, opts.log)(opts.retryOn) else fa
 
     def logWarn(opName: String)(attempt: Int, delay: FiniteDuration, error: Throwable): F[Unit] =
       retries.logWarn(opts.retryConfig, opName, opts.log)(attempt, delay, error)

--- a/tests/src/main/scala/sec/arbitraries.scala
+++ b/tests/src/main/scala/sec/arbitraries.scala
@@ -29,6 +29,7 @@ import StreamState.{Any, NoStream, StreamExists}
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 import sec.api._
+import sec.helpers.implicits._
 
 object arbitraries {
 

--- a/tests/src/main/scala/sec/helpers.scala
+++ b/tests/src/main/scala/sec/helpers.scala
@@ -23,6 +23,26 @@ import sec.api.Endpoint
 
 object helpers {
 
+//======================================================================================================================
+
+  object implicits {
+
+    implicit final class AttemptOps[A](val inner: Attempt[A]) extends AnyVal {
+      def unsafe: A = inner.leftMap(require(false, _)).toOption.get
+    }
+
+    implicit final class ErrorOrOps[A](val inner: ErrorOr[A]) extends AnyVal {
+      def unsafe: A = inner.toOption.get
+    }
+
+    implicit final class BooleanOps(val b: Boolean) extends AnyVal {
+      def fold[A](t: => A, f: => A): A = if (b) t else f
+    }
+
+  }
+
+//======================================================================================================================
+
   object text {
 
     def encodeToBV(content: String): Attempt[ByteVector] =
@@ -38,6 +58,8 @@ object helpers {
     }
   }
 
+//======================================================================================================================
+
   object endpoint {
 
     def endpointFrom(envAddrName: String, envPortName: String, fallbackAddr: String, fallbackPort: Int): Endpoint = {
@@ -47,5 +69,7 @@ object helpers {
     }
 
   }
+
+//======================================================================================================================
 
 }

--- a/tests/src/sit/scala/sec/api/metastreams.scala
+++ b/tests/src/sit/scala/sec/api/metastreams.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import sec.api.MetaStreams.Result
 import sec.api.exceptions.WrongExpectedState
 import sec.syntax.all._
+import sec.helpers.implicits._
 
 class MetaStreamsSuite extends SnSpec {
 

--- a/tests/src/sit/scala/sec/api/streams.scala
+++ b/tests/src/sit/scala/sec/api/streams.scala
@@ -32,6 +32,7 @@ import sec.api.Direction._
 import sec.api.exceptions._
 import sec.syntax.all._
 import helpers.text.mkSnakeCase
+import helpers.implicits._
 
 class StreamsSuite extends SnSpec {
 
@@ -606,10 +607,9 @@ class StreamsSuite extends SnSpec {
 
         "max count deleted events are not resolved" >> {
 
-          val deletedId = genStreamId("streams_read_all_linkto_deleted_")
-          val linkId    = genStreamId("streams_read_all_linkto_link_")
-          def encode(content: String): ByteVector =
-            ByteVector.encodeUtf8(content).leftMap(_.getMessage).unsafe
+          val deletedId               = genStreamId("streams_read_all_linkto_deleted_")
+          val linkId                  = genStreamId("streams_read_all_linkto_link_")
+          def encode(content: String) = ByteVector.encodeUtf8(content).unsafe
 
           def linkData(number: Long) =
             Nel.one(

--- a/tests/src/test/scala/sec/api/mapping/shared.scala
+++ b/tests/src/test/scala/sec/api/mapping/shared.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import org.specs2._
 import com.eventstore.dbclient.proto.shared._
 import sec.api.mapping.shared._
+import sec.helpers.implicits._
 
 class SharedMappingSpec extends mutable.Specification {
 

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -32,6 +32,7 @@ import sec.api.mapping.streams.outgoing
 import sec.api.mapping.streams.incoming
 import sec.api.mapping.implicits._
 import sec.helpers.text.encodeToBV
+import sec.helpers.implicits._
 
 class StreamsMappingSpec extends mutable.Specification {
 
@@ -517,7 +518,7 @@ class StreamsMappingSpec extends mutable.Specification {
       val event       = sampleOfGen(eventGen.eventRecordOne).copy(created = created)
       val eventData   = event.eventData
       val eventType   = sec.EventType.eventTypeToString(event.eventData.eventType)
-      val contentType = eventData.contentType.isBinary.fold(Binary, Json)
+      val contentType = eventData.contentType.fold(Binary, Json)
       val metadata    = Map(ContentType -> contentType, Type -> eventType, Created -> created.getNano().toString)
 
       val recordedEvent = s.ReadResp.ReadEvent

--- a/tests/src/test/scala/sec/event.scala
+++ b/tests/src/test/scala/sec/event.scala
@@ -23,8 +23,8 @@ import java.util.UUID
 import cats.syntax.all._
 import scodec.bits.ByteVector
 import org.specs2.mutable.Specification
-import sec.EventType.InvalidEventType
 import sec.arbitraries._
+import sec.helpers.implicits._
 import sec.helpers.text.encodeToBV
 
 //======================================================================================================================
@@ -129,15 +129,9 @@ class EventTypeSpec extends Specification {
   val sys: EventType = EventType.systemDefined("system").unsafe
 
   "apply" >> {
-    EventType("") should beLeft("Event type name cannot be empty")
-    EventType("$users") should beLeft("value must not start with $, but is $users")
+    EventType("") should beLeft(InvalidInput("Event type name cannot be empty"))
+    EventType("$users") should beLeft(InvalidInput("value must not start with $, but is $users"))
     EventType("users") should beRight(EventType.userDefined("users").unsafe)
-  }
-
-  "of" >> {
-    EventType.of[ErrorOr]("") should beLeft(InvalidEventType("Event type name cannot be empty"))
-    EventType.of[ErrorOr]("$users") should beLeft(InvalidEventType("value must not start with $, but is $users"))
-    EventType.of[ErrorOr]("users") should beRight(EventType.userDefined("users").unsafe)
   }
 
   "eventTypeToString" >> {
@@ -189,8 +183,8 @@ class EventDataSpec extends Specification {
 
   "apply" >> {
 
-    val errEmpty = "Event type name cannot be empty"
-    val errStart = "value must not start with $, but is $system"
+    val errEmpty = InvalidInput("Event type name cannot be empty")
+    val errStart = InvalidInput("value must not start with $, but is $system")
 
     def testCommon(data: ByteVector, meta: ByteVector, ct: ContentType) = {
 

--- a/tests/src/test/scala/sec/id.scala
+++ b/tests/src/test/scala/sec/id.scala
@@ -21,6 +21,7 @@ import org.scalacheck._
 import cats.kernel.laws.discipline._
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
+import sec.helpers.implicits._
 import sec.arbitraries._
 
 class StreamIdSpec extends Specification with Discipline {
@@ -31,8 +32,8 @@ class StreamIdSpec extends Specification with Discipline {
   val systemId: StreamId.System = StreamId.system("system").unsafe
 
   "apply" >> {
-    StreamId("") should beLeft("name cannot be empty")
-    StreamId("$$meta") should beLeft("value must not start with $$, but is $$meta")
+    StreamId("") should beLeft(InvalidInput("name cannot be empty"))
+    StreamId("$$meta") should beLeft(InvalidInput("value must not start with $$, but is $$meta"))
     StreamId("$users") shouldEqual StreamId.system("users")
     StreamId("users") shouldEqual StreamId.normal("users")
     StreamId(ss.All) shouldEqual StreamId.All.asRight
@@ -40,25 +41,6 @@ class StreamIdSpec extends Specification with Discipline {
     StreamId(ss.Stats) shouldEqual StreamId.Stats.asRight
     StreamId(ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
     StreamId(ss.Streams) shouldEqual StreamId.Streams.asRight
-  }
-
-  "of" >> {
-
-    StreamId.of[ErrorOr]("") should beLike { case Left(StreamId.StreamIdError("name cannot be empty")) =>
-      ok
-    }
-
-    StreamId.of[ErrorOr]("$$m") should beLike {
-      case Left(StreamId.StreamIdError("value must not start with $$, but is $$m")) => ok
-    }
-
-    StreamId.of[ErrorOr]("$users") shouldEqual StreamId.system("users")
-    StreamId.of[ErrorOr]("users") shouldEqual StreamId.normal("users")
-    StreamId.of[ErrorOr](ss.All) shouldEqual StreamId.All.asRight
-    StreamId.of[ErrorOr](ss.Settings) shouldEqual StreamId.Settings.asRight
-    StreamId.of[ErrorOr](ss.Stats) shouldEqual StreamId.Stats.asRight
-    StreamId.of[ErrorOr](ss.Scavenges) shouldEqual StreamId.Scavenges.asRight
-    StreamId.of[ErrorOr](ss.Streams) shouldEqual StreamId.Streams.asRight
   }
 
   "streamIdToString" >> {

--- a/tests/src/test/scala/sec/metadata.scala
+++ b/tests/src/test/scala/sec/metadata.scala
@@ -22,6 +22,7 @@ import org.specs2.mutable.Specification
 import io.circe._
 import io.circe.syntax._
 import sec.arbitraries._
+import sec.helpers.implicits._
 
 //======================================================================================================================
 
@@ -105,7 +106,7 @@ class MetaStateSpec extends Specification {
   "show" >> {
 
     MetaState.empty
-      .copy(maxAge = MaxAge(10.days).unsafe.some, maxCount = MaxCount(1).unsafe.some)
+      .copy(maxAge = MaxAge(10.days).toOption, maxCount = MaxCount(1).toOption)
       .show shouldEqual s"""
        |MetaState:
        |  max-age         = 10 days
@@ -117,8 +118,8 @@ class MetaStateSpec extends Specification {
 
     MetaState(
       maxAge         = None,
-      maxCount       = MaxCount(50).unsafe.some,
-      cacheControl   = CacheControl(12.hours).unsafe.some,
+      maxCount       = MaxCount(50).toOption,
+      cacheControl   = CacheControl(12.hours).toOption,
       truncateBefore = StreamPosition.exact(1000L).some,
       acl            = StreamAcl.empty.copy(readRoles = Set("a", "b")).some
     ).show shouldEqual s"""

--- a/tests/src/test/scala/sec/utilities.scala
+++ b/tests/src/test/scala/sec/utilities.scala
@@ -17,32 +17,10 @@
 package sec
 
 import scala.concurrent.duration._
-import scala.util.control.NoStackTrace
-import cats.syntax.all._
 import org.specs2.mutable.Specification
 import sec.utilities._
 
 class UtilitiesSpec extends Specification {
-
-  import UtilitiesSpec._
-
-  "AttemptOps" >> {
-    "unsafe" >> {
-      "oops".asLeft[Int].unsafe should throwA[IllegalArgumentException]("oops")
-      1.asRight[String].unsafe shouldEqual 1
-    }
-
-    "orFail" >> {
-      "oops".asLeft[Int].orFail[ErrorOr](Oops) shouldEqual Oops("oops").asLeft
-    }
-  }
-
-  "BooleanOps" >> {
-    "fold" >> {
-      true.fold("t", "f") shouldEqual "t"
-      false.fold("t", "f") shouldEqual "f"
-    }
-  }
 
   "guardNonEmpty" >> {
     guardNonEmpty("x")(null) should beLeft("x cannot be empty")
@@ -61,8 +39,4 @@ class UtilitiesSpec extends Specification {
     format(4831.millis) shouldEqual "4.831s"
   }
 
-}
-
-object UtilitiesSpec {
-  final case class Oops(msg: String) extends RuntimeException(msg) with NoStackTrace
 }

--- a/tests/src/test/scala/sec/version.scala
+++ b/tests/src/test/scala/sec/version.scala
@@ -46,23 +46,10 @@ class VersionSpec extends Specification with Discipline {
 
   "StreamPosition" >> {
 
-    import StreamPosition.Exact
-    import StreamPosition.Exact.InvalidExact
-
     "apply" >> {
-      StreamPosition(-1L) shouldEqual StreamPosition.End
-      StreamPosition(0L) shouldEqual StreamPosition.exact(0L)
-      StreamPosition(1L) shouldEqual StreamPosition.exact(1L)
-    }
-
-    "Exact.apply" >> {
-      Exact(-1L) should beLeft("value must be >= 0, but is -1")
-      Exact(0L) should beRight(StreamPosition.exact(0L))
-    }
-
-    "Exact.of" >> {
-      Exact.of[ErrorOr](-1L) should beLeft(InvalidExact("value must be >= 0, but is -1"))
-      Exact.of[ErrorOr](0L) should beRight(StreamPosition.exact(0L))
+      StreamPosition(0L) should beRight(StreamPosition.exact(0L))
+      StreamPosition(1L) should beRight(StreamPosition.exact(1L))
+      StreamPosition(-1L) should beLeft(InvalidInput("value must be >= 0, but is -1"))
     }
 
     "Show" >> {
@@ -76,26 +63,15 @@ class VersionSpec extends Specification with Discipline {
     }
   }
 
-  "Position" >> {
-
-    import LogPosition.Exact
+  "LogPosition" >> {
 
     "apply" >> {
-      LogPosition(-1L, -1L) should beRight[LogPosition](LogPosition.End)
-      LogPosition(-1L, 0L) should beRight[LogPosition](LogPosition.End)
-      LogPosition(0L, -1L) should beRight[LogPosition](LogPosition.End)
       LogPosition(0L, 0L) should beRight(LogPosition.exact(0L, 0L))
       LogPosition(1L, 0L) should beRight(LogPosition.exact(1L, 0L))
       LogPosition(1L, 1L) should beRight(LogPosition.exact(1L, 1L))
-      LogPosition(0L, 1L) should beLeft("commit must be >= prepare, but 0 < 1")
-    }
-
-    "Exact.apply" >> {
-      Exact(-1L, 0L) should beLeft("commit must be >= 0, but is -1")
-      Exact(0L, -1L) should beLeft("prepare must be >= 0, but is -1")
-      Exact(0L, 1L) should beLeft("commit must be >= prepare, but 0 < 1")
-      Exact(0L, 0L) should beRight(LogPosition.exact(0L, 0L))
-      Exact(1L, 0L) should beRight(LogPosition.exact(1L, 0L))
+      LogPosition(-1L, 0L) should beLeft(InvalidInput("commit must be >= 0, but is -1"))
+      LogPosition(0L, -1L) should beLeft(InvalidInput("prepare must be >= 0, but is -1"))
+      LogPosition(0L, 1L) should beLeft(InvalidInput("commit must be >= prepare, but 0 < 1"))
     }
 
     "Show" >> {


### PR DESCRIPTION
 - use the least powerful, yet sufficient, signature for
   data construction of basic types.

 - remove `AttemptOps` / `BooleanOps` from sec package as
   it is only used in tests or for convenience.

 - adjust tests and add implicits to helpers.