### PR TITLE
deps/grpc: avoid transient grpc via scalapb + shaded netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ lazy val core = project
   .settings(commonSettings)
   .settings(
     name := "sec-core",
-    libraryDependencies ++= compileM(cats, scodecBits, circe, scalaPb, grpcApi),
+    libraryDependencies ++=
+      compileM(cats, scodecBits, circe, scalaPb, grpcApi, grpcStub, grpcProtobuf, grpcCore),
     Compile / PB.protoSources := Seq((LocalRootProject / baseDirectory).value / "protobuf"),
     Compile / PB.targets := Seq(scalapb.gen(flatPackage = true, grpc = false) -> (sourceManaged in Compile).value)
   )
@@ -54,7 +55,7 @@ lazy val `fs2-netty` = project
   .in(file("fs2-netty"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
-  .settings(name := "sec-fs2-client", libraryDependencies ++= compileM(grpcNetty, tcnative))
+  .settings(name := "sec-fs2-client", libraryDependencies ++= compileM(grpcNetty))
   .dependsOn(`fs2-core`)
 
 //==== Tests ===========================================================================================================

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,7 +14,7 @@ slug: /
 To use @libName@ in an existing [sbt](https://www.scala-sbt.org) project with Scala 2.13 or a later version, 
 add the following to your `build.sbt` file.
 ```scala
-libraryDependencies += "io.github.ahjohannessen" % "sec-fs2" % "@libVersion@"
+libraryDependencies += "io.github.ahjohannessen" %% "sec-fs2" % "@libVersion@"
 ```
 
 ### How to learn

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,7 +29,7 @@ you configure ESDB for production usage.
 
 Create a new project with @libName@ as dependency:
 ```scala
-libraryDependencies += "io.github.ahjohannessen" % "sec-fs2" % "@libVersion@"
+libraryDependencies += "io.github.ahjohannessen" %% "sec-fs2" % "@libVersion@"
 ```
 
 ### Verify Your Setup

--- a/fs2-netty/src/main/scala/sec/api/netty.scala
+++ b/fs2-netty/src/main/scala/sec/api/netty.scala
@@ -20,10 +20,10 @@ package api
 import java.nio.file.Path
 import cats.effect._
 import cats.syntax.all._
-import io.grpc.netty.NettyChannelBuilder
-import io.grpc.netty.NettyChannelBuilder.{forAddress, forTarget}
-import io.grpc.netty.GrpcSslContexts.forClient
-import io.netty.handler.ssl.SslContext
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder.{forAddress, forTarget}
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts.forClient
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext
 
 object netty {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,8 +13,7 @@ object Dependencies {
     val scodecBits       = "1.1.20"
     val circe            = "0.13.0"
     val scalaPb          = scalapb.compiler.Version.scalapbVersion
-    val grpc             = org.lyranthe.fs2_grpc.buildinfo.BuildInfo.grpcVersion
-    val tcnative         = "2.0.30.Final"
+    val grpc             = "1.32.2"
     val disciplineSpecs2 = "1.1.0"
     val specs2           = "4.10.5"
     val catsEffectSpecs2 = "0.4.1"
@@ -23,18 +22,20 @@ object Dependencies {
 
   // Compile
 
-  val cats         = "org.typelevel"        %% "cats-core"                       % versions.catsCore
-  val catsEffect   = "org.typelevel"        %% "cats-effect"                     % versions.catsEffect
-  val fs2          = "co.fs2"               %% "fs2-core"                        % versions.fs2
-  val log4cats     = "io.chrisdavenport"    %% "log4cats-core"                   % versions.log4cats
-  val log4catsNoop = "io.chrisdavenport"    %% "log4cats-noop"                   % versions.log4cats
-  val scodecBits   = "org.scodec"           %% "scodec-bits"                     % versions.scodecBits
-  val circe        = "io.circe"             %% "circe-core"                      % versions.circe
-  val circeParser  = "io.circe"             %% "circe-parser"                    % versions.circe
-  val scalaPb      = "com.thesamet.scalapb" %% "scalapb-runtime"                 % versions.scalaPb
-  val grpcApi      = "io.grpc"               % "grpc-api"                        % versions.grpc
-  val grpcNetty    = "io.grpc"               % "grpc-netty"                      % versions.grpc
-  val tcnative     = "io.netty"              % "netty-tcnative-boringssl-static" % versions.tcnative
+  val cats         = "org.typelevel"        %% "cats-core"         % versions.catsCore
+  val catsEffect   = "org.typelevel"        %% "cats-effect"       % versions.catsEffect
+  val fs2          = "co.fs2"               %% "fs2-core"          % versions.fs2
+  val log4cats     = "io.chrisdavenport"    %% "log4cats-core"     % versions.log4cats
+  val log4catsNoop = "io.chrisdavenport"    %% "log4cats-noop"     % versions.log4cats
+  val scodecBits   = "org.scodec"           %% "scodec-bits"       % versions.scodecBits
+  val circe        = "io.circe"             %% "circe-core"        % versions.circe
+  val circeParser  = "io.circe"             %% "circe-parser"      % versions.circe
+  val scalaPb      = "com.thesamet.scalapb" %% "scalapb-runtime"   % versions.scalaPb
+  val grpcApi      = "io.grpc"               % "grpc-api"          % versions.grpc
+  val grpcStub     = "io.grpc"               % "grpc-stub"         % versions.grpc
+  val grpcCore     = "io.grpc"               % "grpc-core"         % versions.grpc
+  val grpcProtobuf = "io.grpc"               % "grpc-protobuf"     % versions.grpc
+  val grpcNetty    = "io.grpc"               % "grpc-netty-shaded" % versions.grpc
 
   // Testing
 


### PR DESCRIPTION
 - in order to move grpc forwards without depending on
   fs2-grpc and scalapb, grpc dependencies that are used
   are explicitly added to sec-core.

 - in order to avoid mismatch with tcnative and the like,
   grpc-netty-shaded is used.