### PR TITLE
ci: use latest master es image from quay.io

### DIFF
--- a/.docker/cluster.ci.yml
+++ b/.docker/cluster.ci.yml
@@ -6,7 +6,7 @@ x-common-variables: &common-variables
 services:
 
   es1:
-    image: quay.io/ahjohannessen/es-v6:channels
+    image: quay.io/ahjohannessen/es-v6:latest
     env_file:
       - shared.env
     environment:
@@ -24,7 +24,7 @@ services:
       - cert-gen
 
   es2:
-    image: quay.io/ahjohannessen/es-v6:channels
+    image: quay.io/ahjohannessen/es-v6:latest
     env_file:
       - shared.env
     environment:
@@ -42,7 +42,7 @@ services:
       - cert-gen
 
   es3:
-    image: quay.io/ahjohannessen/es-v6:channels
+    image: quay.io/ahjohannessen/es-v6:latest
     env_file:
       - shared.env
     environment:

--- a/.docker/single-node.ci.yml
+++ b/.docker/single-node.ci.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   es:
-    image: quay.io/ahjohannessen/es-v6:channels
+    image: quay.io/ahjohannessen/es-v6:latest
     env_file:
       - shared.env
     environment:


### PR DESCRIPTION
 - use latest master es image from quay.io
   until official image is available with
   one off channel fixes.