### PR TITLE
api: make creds a method + meta on client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v5
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.java }}
 
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v5
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.java }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -161,6 +161,12 @@ inThisBuild(
     githubWorkflowJavaVersions := Seq("adopt@1.11"),
     githubWorkflowTargetTags += "v*",
     githubWorkflowTargetBranches := Seq("master"),
+    githubWorkflowJobSetup := {
+      githubWorkflowJobSetup.value.map {
+        case use @ WorkflowStep.Use("olafurpg", "setup-scala", _, _, _, _, _, _) => use.copy(ref = "v10")
+        case ws                                                                  => ws
+      }
+    },
     githubWorkflowBuildPreamble += WorkflowStep.Run(
       name     = Some("Start Single Node"),
       commands = List(".docker/single-node.sh up -d"),

--- a/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
@@ -20,11 +20,7 @@ package syntax
 import scala.concurrent.duration.FiniteDuration
 import cats.syntax.all._
 import sec.api._
-import sec.api.MetaStreams._
-import StreamPosition.Exact
 import StreamId.Id
-
-//====================================================================================================================
 
 trait MetaStreamsSyntax {
 
@@ -32,104 +28,18 @@ trait MetaStreamsSyntax {
     new MetaStreamsOps[F](ms)
 }
 
-//====================================================================================================================
-
 final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
 
-  def getMaxAge(id: Id): F[Option[ReadResult[MaxAge]]] =
-    ms.getMaxAge(id, None)
-
   def setMaxAge(id: Id, expectedState: StreamState, age: FiniteDuration): F[WriteResult] =
-    setMaxAgeF(id, expectedState, age, None)
-
-  def setMaxAge(id: Id, expectedState: StreamState, age: FiniteDuration, uc: UserCredentials): F[WriteResult] =
-    setMaxAgeF(id, expectedState, age, uc.some)
-
-  private def setMaxAgeF(id: Id, er: StreamState, age: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-    MaxAge(age).liftTo[F] >>= (ms.setMaxAge(id, er, _, uc))
-
-  def unsetMaxAge(id: Id, expectedState: StreamState): F[WriteResult] =
-    ms.unsetMaxAge(id, expectedState, None)
-
-  def getMaxCount(id: Id): F[Option[ReadResult[MaxCount]]] =
-    ms.getMaxCount(id, None)
+    MaxAge(age).liftTo[F] >>= (ms.setMaxAge(id, expectedState, _))
 
   def setMaxCount(id: Id, expectedState: StreamState, count: Int): F[WriteResult] =
-    setMaxCountF(id, expectedState, count, None)
-
-  def setMaxCount(id: Id, expectedState: StreamState, count: Int, uc: UserCredentials): F[WriteResult] =
-    setMaxCountF(id, expectedState, count, uc.some)
-
-  private def setMaxCountF(id: Id, er: StreamState, count: Int, uc: Option[UserCredentials]): F[WriteResult] =
-    MaxCount(count).liftTo[F] >>= (ms.setMaxCount(id, er, _, uc))
-
-  def unsetMaxCount(id: Id, expectedState: StreamState): F[WriteResult] =
-    ms.unsetMaxCount(id, expectedState, None)
-
-  def getCacheControl(id: Id): F[Option[ReadResult[CacheControl]]] =
-    ms.getCacheControl(id, None)
+    MaxCount(count).liftTo[F] >>= (ms.setMaxCount(id, expectedState, _))
 
   def setCacheControl(id: Id, expectedState: StreamState, cacheControl: FiniteDuration): F[WriteResult] =
-    setCacheControlF(id, expectedState, cacheControl, None)
-
-  def setCacheControl(
-    id: Id,
-    expectedState: StreamState,
-    cacheControl: FiniteDuration,
-    uc: UserCredentials
-  ): F[WriteResult] =
-    setCacheControlF(id, expectedState, cacheControl, uc.some)
-
-  private def setCacheControlF(
-    id: Id,
-    er: StreamState,
-    cc: FiniteDuration,
-    uc: Option[UserCredentials]
-  ): F[WriteResult] =
-    CacheControl(cc).liftTo[F] >>= (ms.setCacheControl(id, er, _, uc))
-
-  def unsetCacheControl(id: Id, expectedState: StreamState): F[WriteResult] =
-    ms.unsetCacheControl(id, expectedState, None)
-
-  def getAcl(id: Id): F[Option[ReadResult[StreamAcl]]] =
-    ms.getAcl(id, None)
-
-  def setAcl(id: Id, expectedState: StreamState, acl: StreamAcl): F[WriteResult] =
-    ms.setAcl(id, expectedState, acl, None)
-
-  def unsetAcl(id: Id, expectedState: StreamState): F[WriteResult] =
-    ms.unsetAcl(id, expectedState, None)
-
-  def getTruncateBefore(id: Id): F[Option[ReadResult[Exact]]] =
-    ms.getTruncateBefore(id, None)
+    CacheControl(cacheControl).liftTo[F] >>= (ms.setCacheControl(id, expectedState, _))
 
   def setTruncateBefore(id: Id, expectedState: StreamState, truncateBefore: Long): F[WriteResult] =
-    setTruncateBeforeF(id, expectedState, truncateBefore, None)
+    StreamPosition(truncateBefore).liftTo[F] >>= (ms.setTruncateBefore(id, expectedState, _))
 
-  def setTruncateBefore(
-    id: Id,
-    expectedState: StreamState,
-    truncateBefore: Long,
-    uc: UserCredentials
-  ): F[WriteResult] =
-    setTruncateBeforeF(id, expectedState, truncateBefore, uc.some)
-
-  private def setTruncateBeforeF(id: Id, er: StreamState, tb: Long, uc: Option[UserCredentials]): F[WriteResult] =
-    StreamPosition(tb).liftTo[F] >>= (ms.setTruncateBefore(id, er, _, uc))
-
-  def unsetTruncateBefore(id: Id, expectedState: StreamState): F[WriteResult] =
-    ms.unsetTruncateBefore(id, expectedState, None)
-
-  ///
-
-  private[sec] def getMetadata(id: Id): F[Option[MetaResult]] =
-    ms.getMetadata(id, None)
-
-  private[sec] def setMetadata(id: Id, expectedState: StreamState, data: StreamMetadata): F[WriteResult] =
-    ms.setMetadata(id, expectedState, data, None)
-
-  private[sec] def unsetMetadata(id: Id, expectedState: StreamState): F[WriteResult] =
-    ms.unsetMetadata(id, expectedState, None)
 }
-
-//====================================================================================================================

--- a/fs2/src/main/scala-3/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/metastreams.scala
@@ -20,95 +20,24 @@ package syntax
 import scala.concurrent.duration.FiniteDuration
 import cats.syntax.all._
 import sec.api._
-import sec.api.MetaStreams._
-import StreamPosition.Exact
 import StreamId.Id
-
-//====================================================================================================================
 
 trait MetaStreamsSyntax {
 
   extension [F[_]: ErrorM](ms: MetaStreams[F]) {
 
-    def getMaxAge(id: Id): F[Option[ReadResult[MaxAge]]] =
-      ms.getMaxAge(id, None)
+  def setMaxAge(id: Id, expectedState: StreamState, age: FiniteDuration): F[WriteResult] =
+    MaxAge(age).liftTo[F] >>= (ms.setMaxAge(id, expectedState, _))
 
-    def setMaxAge(id: Id, expectedState: StreamState, age: FiniteDuration): F[WriteResult] =
-      setMaxAgeF(id, expectedState, age, None)
+  def setMaxCount(id: Id, expectedState: StreamState, count: Int): F[WriteResult] =
+    MaxCount(count).liftTo[F] >>= (ms.setMaxCount(id, expectedState, _))
 
-    def setMaxAge(id: Id, expectedState: StreamState, age: FiniteDuration, uc: UserCredentials): F[WriteResult] =
-      setMaxAgeF(id, expectedState, age, uc.some)
-      
-    private def setMaxAgeF(id: Id, er: StreamState, m: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-      MaxAge(m).liftTo[F] >>= (ms.setMaxAge(id, er, _, uc))
+  def setCacheControl(id: Id, expectedState: StreamState, cacheControl: FiniteDuration): F[WriteResult] =
+    CacheControl(cacheControl).liftTo[F] >>= (ms.setCacheControl(id, expectedState, _))
 
-    def unsetMaxAge(id: Id, expectedState: StreamState): F[WriteResult] =
-      ms.unsetMaxAge(id, expectedState, None)
+  def setTruncateBefore(id: Id, expectedState: StreamState, truncateBefore: Long): F[WriteResult] =
+    StreamPosition(truncateBefore).liftTo[F] >>= (ms.setTruncateBefore(id, expectedState, _))
 
-    def getMaxCount(id: Id): F[Option[ReadResult[MaxCount]]] =
-      ms.getMaxCount(id, None)
-
-    def setMaxCount(id: Id, expectedState: StreamState, count: Int): F[WriteResult] =
-      setMaxCountF(id, expectedState, count, None)
-
-    def setMaxCount(id: Id, expectedState: StreamState, count: Int, uc: UserCredentials): F[WriteResult] =
-      setMaxCountF(id, expectedState, count, uc.some)
-      
-    private def setMaxCountF(id: Id, er: StreamState, count: Int, uc: Option[UserCredentials]): F[WriteResult] =
-      MaxCount(count).liftTo[F] >>= (ms.setMaxCount(id, er, _, uc))
-
-    def unsetMaxCount(id: Id, expectedState: StreamState): F[WriteResult] =
-      ms.unsetMaxCount(id, expectedState, None)
-
-    def getCacheControl(id: Id): F[Option[ReadResult[CacheControl]]] =
-      ms.getCacheControl(id, None)
-
-    def setCacheControl(id: Id, expectedState: StreamState, cacheControl: FiniteDuration): F[WriteResult] =
-      setCacheControlF(id, expectedState, cacheControl, None)
-
-    def setCacheControl(id: Id, expectedState: StreamState, cacheControl: FiniteDuration, uc: UserCredentials): F[WriteResult] =
-      setCacheControlF(id, expectedState, cacheControl, uc.some)
-      
-    private def setCacheControlF(id: Id, er: StreamState, cacheControl: FiniteDuration, uc: Option[UserCredentials]): F[WriteResult] =
-      CacheControl(cacheControl).liftTo[F] >>= (ms.setCacheControl(id, er, _, uc))
-
-    def unsetCacheControl(id: Id, expectedState: StreamState): F[WriteResult] =
-      ms.unsetCacheControl(id, expectedState, None)
-
-    def getAcl(id: Id): F[Option[ReadResult[StreamAcl]]] =
-      ms.getAcl(id, None)
-
-    def setAcl(id: Id, expectedState: StreamState, acl: StreamAcl): F[WriteResult] =
-      ms.setAcl(id, expectedState, acl, None)
-
-    def unsetAcl(id: Id, expectedState: StreamState): F[WriteResult] =
-      ms.unsetAcl(id, expectedState, None)
-
-    def getTruncateBefore(id: Id): F[Option[ReadResult[Exact]]] =
-      ms.getTruncateBefore(id, None)
-
-    def setTruncateBefore(id: Id, expectedState: StreamState, truncateBefore: Long): F[WriteResult] =
-      setTruncateBeforeF(id, expectedState, truncateBefore, None)
-
-    def setTruncateBefore(id: Id, expectedState: StreamState, truncateBefore: Long, uc: UserCredentials): F[WriteResult] =
-      setTruncateBeforeF(id, expectedState, truncateBefore, uc.some)
-      
-    private def setTruncateBeforeF(id: Id, er: StreamState, tb: Long, uc: Option[UserCredentials]): F[WriteResult] =
-      StreamPosition(tb).liftTo[F] >>= (ms.setTruncateBefore(id, er, _, uc))
-
-    def unsetTruncateBefore(id: Id, expectedState: StreamState): F[WriteResult] =
-      ms.unsetTruncateBefore(id, expectedState, None)
-
-    private[sec] def getMetadata(id: Id): F[Option[MetaResult]] =
-      ms.getMetadata(id, None)
-
-    private[sec] def setMetadata(id: Id, expectedState: StreamState, data: StreamMetadata): F[WriteResult] =
-      ms.setMetadata(id, expectedState, data, None)
-
-    private[sec] def removeMetadata(id: Id, expectedState: StreamState): F[WriteResult] =
-      ms.unsetMetadata(id, expectedState, None)
   }
 
 }
-
-//====================================================================================================================

--- a/fs2/src/main/scala/sec/api/client.scala
+++ b/fs2/src/main/scala/sec/api/client.scala
@@ -34,6 +34,7 @@ import scala.concurrent.duration._
 
 trait EsClient[F[_]] {
   def streams: Streams[F]
+  def metaStreams: MetaStreams[F]
   def gossip: Gossip[F]
 }
 
@@ -62,6 +63,8 @@ object EsClient {
       mkContext(options, requiresLeader),
       mkOpts[F](options.operationOptions, logger, "Streams")
     )
+
+    val metaStreams: MetaStreams[F] = MetaStreams[F](streams)
 
     val gossip: Gossip[F] = Gossip(
       mkGossipFs2Grpc[F](mc),

--- a/fs2/src/main/scala/sec/api/cluster/watch.scala
+++ b/fs2/src/main/scala/sec/api/cluster/watch.scala
@@ -61,7 +61,7 @@ private[sec] object ClusterWatch {
       updates   = mkWatch(store.get, options.notificationInterval).subscribe
       provider <- mkProvider(updates)
       channel  <- mkChannel(provider)
-      watch    <- create[F](gossipFn(channel).read(None), options, store, logger)
+      watch    <- create[F](gossipFn(channel).read, options, store, logger)
     } yield watch
 
   }

--- a/fs2/src/main/scala/sec/syntax/api.scala
+++ b/fs2/src/main/scala/sec/syntax/api.scala
@@ -17,7 +17,6 @@
 package sec
 package syntax
 
-import cats.data.NonEmptyList
 import fs2.Stream
 import sec.api._
 
@@ -36,27 +35,21 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
   /// Subscription
 
   def subscribeToAll(
-    exclusiveFrom: Option[LogPosition],
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    exclusiveFrom: Option[LogPosition]
   ): Stream[F, Event] =
-    s.subscribeToAll(exclusiveFrom, resolveLinkTos, credentials)
+    s.subscribeToAll(exclusiveFrom, resolveLinkTos = false)
 
   def subscribeToAllFiltered(
     exclusiveFrom: Option[LogPosition],
-    filterOptions: SubscriptionFilterOptions,
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    filterOptions: SubscriptionFilterOptions
   ): Stream[F, Either[Checkpoint, Event]] =
-    s.subscribeToAll(exclusiveFrom, filterOptions, resolveLinkTos, credentials)
+    s.subscribeToAll(exclusiveFrom, filterOptions, resolveLinkTos = false)
 
   def subscribeToStream(
     streamId: StreamId,
-    exclusiveFrom: Option[StreamPosition],
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    exclusiveFrom: Option[StreamPosition]
   ): Stream[F, Event] =
-    s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos, credentials)
+    s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos = false)
 
   /// Read
 
@@ -64,61 +57,31 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     streamId: StreamId,
     from: StreamPosition = StreamPosition.Start,
     maxCount: Long = Long.MaxValue,
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    resolveLinkTos: Boolean = false
   ): Stream[F, Event] =
-    s.readStream(streamId, from, Direction.Forwards, maxCount, resolveLinkTos, credentials)
+    s.readStream(streamId, from, Direction.Forwards, maxCount, resolveLinkTos)
 
   def readStreamBackwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.End,
     maxCount: Long = Long.MaxValue,
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    resolveLinkTos: Boolean = false
   ): Stream[F, Event] =
-    s.readStream(streamId, from, Direction.Backwards, maxCount, resolveLinkTos, credentials)
+    s.readStream(streamId, from, Direction.Backwards, maxCount, resolveLinkTos)
 
   def readAllForwards(
     from: LogPosition = LogPosition.Start,
     maxCount: Long = Long.MaxValue,
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    resolveLinkTos: Boolean = false
   ): Stream[F, Event] =
-    s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos, credentials)
+    s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos)
 
   def readAllBackwards(
     from: LogPosition = LogPosition.End,
     maxCount: Long = Long.MaxValue,
-    resolveLinkTos: Boolean = false,
-    credentials: Option[UserCredentials] = None
+    resolveLinkTos: Boolean = false
   ): Stream[F, Event] =
-    s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos, credentials)
-
-  /// Append
-
-  def appendToStream(
-    streamId: StreamId,
-    expectedState: StreamState,
-    events: NonEmptyList[EventData],
-    credentials: Option[UserCredentials] = None
-  ): F[WriteResult] =
-    s.appendToStream(streamId, expectedState, events, credentials)
-
-  /// Delete
-
-  def delete(
-    streamId: StreamId,
-    expectedState: StreamState,
-    credentials: Option[UserCredentials] = None
-  ): F[DeleteResult] =
-    s.delete(streamId, expectedState, credentials)
-
-  def tombstone(
-    streamId: StreamId,
-    expectedState: StreamState,
-    credentials: Option[UserCredentials] = None
-  ): F[DeleteResult] =
-    s.tombstone(streamId, expectedState, credentials)
+    s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos)
 
 }
 

--- a/tests/src/cit/scala/sec/api/cluster.scala
+++ b/tests/src/cit/scala/sec/api/cluster.scala
@@ -27,7 +27,7 @@ class ClusterSuite extends CSpec {
     "be reachable" >> {
 
       fs2.Stream
-        .eval(gossip.read(None))
+        .eval(gossip.read)
         .evalTap(x => log.info(s"Gossip.read: ${x.show}"))
         .metered(150.millis)
         .repeat

--- a/tests/src/main/scala/sec/specs.scala
+++ b/tests/src/main/scala/sec/specs.scala
@@ -43,6 +43,6 @@ trait ClientSpec extends ResourceSpec[EsClient[IO]] {
 
   final def client: EsClient[IO]         = resource
   final def streams: Streams[IO]         = client.streams
-  final def metaStreams: MetaStreams[IO] = client.streams.metadata
+  final def metaStreams: MetaStreams[IO] = client.metaStreams
   final def gossip: Gossip[IO]           = client.gossip
 }

--- a/tests/src/sit/scala/sec/api/gossip.scala
+++ b/tests/src/sit/scala/sec/api/gossip.scala
@@ -25,11 +25,9 @@ class GossipSuite extends SnSpec {
 
     "read" >> {
 
-      gossip
-        .read(None)
-        .map(_.members.headOption should beLike {
-          case Some(MemberInfo(_, _, VNodeState.Leader, true, Endpoint("127.0.0.1", 2113))) => ok
-        })
+      gossip.read.map(_.members.headOption should beLike {
+        case Some(MemberInfo(_, _, VNodeState.Leader, true, Endpoint("127.0.0.1", 2113))) => ok
+      })
     }
   }
 

--- a/tests/src/sit/scala/sec/api/metastreams.scala
+++ b/tests/src/sit/scala/sec/api/metastreams.scala
@@ -215,11 +215,11 @@ class MetaStreamsSuite extends SnSpec {
         for {
           sid <- mkStreamId("custom_api").pure[IO]
           foo <- Foo(bars = (1 to 5).map(i => Bar(i.toString)).toList).pure[IO]
-          ma1 <- metaStreams.getCustom[Foo](sid, None)
-          wr1 <- metaStreams.setCustom(sid, NoStream, foo, None)
-          ma2 <- metaStreams.getCustom[Foo](sid, None)
-          wr2 <- metaStreams.unsetCustom(sid, wr1.streamPosition, None)
-          ma3 <- metaStreams.getCustom[Foo](sid, None)
+          ma1 <- metaStreams.getCustom[Foo](sid)
+          wr1 <- metaStreams.setCustom(sid, NoStream, foo)
+          ma2 <- metaStreams.getCustom[Foo](sid)
+          wr2 <- metaStreams.unsetCustom(sid, wr1.streamPosition)
+          ma3 <- metaStreams.getCustom[Foo](sid)
         } yield {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start


### PR DESCRIPTION
 - move optional user credentials from api methods
   to a `withCredentials` method that preserves
   same functionality, but cuts down on repetition.

 - make `MetaStreams` first class on `EsClient` and
   remove it from `Streams` api.

 - overrule ci setup scala.