### PR TITLE
core: api doc / new api type / rm examples

### DIFF
--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -344,9 +344,9 @@ private[sec] object streams {
         .map(p => DeleteResult(LogPosition.exact(p.commitPosition, p.preparePosition)))
         .require[F]("DeleteResp.PositionOptions.Position")
 
-    def mkDeleteResult[F[_]: ErrorA](tr: TombstoneResp): F[DeleteResult] =
+    def mkTombstoneResult[F[_]: ErrorA](tr: TombstoneResp): F[TombstoneResult] =
       tr.positionOption.position
-        .map(p => DeleteResult(LogPosition.exact(p.commitPosition, p.preparePosition)))
+        .map(p => TombstoneResult(LogPosition.exact(p.commitPosition, p.preparePosition)))
         .require[F]("TombstoneResp.PositionOptions.Position")
 
   }

--- a/core/src/main/scala/sec/api/streams.scala
+++ b/core/src/main/scala/sec/api/streams.scala
@@ -17,8 +17,42 @@
 package sec
 package api
 
-final case class Checkpoint(logPosition: LogPosition.Exact)
-final case class WriteResult(streamPosition: StreamPosition.Exact, logPosition: LogPosition.Exact)
-final case class DeleteResult(logPosition: LogPosition.Exact)
+/**
+ * Checkpoint result used with server-side filtering in EventStoreDB.
+ * Contains the [[LogPosition.Exact]] when the checkpoint was made.
+ */
+final case class Checkpoint(
+  logPosition: LogPosition.Exact
+)
 
-final private[sec] case class SubscriptionConfirmation(id: String)
+/**
+ * The current last [[StreamPosition.Exact]] of the stream
+ * appended to and its corresponding [[LogPosition.Exact]] in the transaction log.
+ */
+final case class WriteResult(
+  streamPosition: StreamPosition.Exact,
+  logPosition: LogPosition.Exact
+)
+
+/**
+ * The [[LogPosition.Exact]] of the delete in the transaction log.
+ */
+final case class DeleteResult(
+  logPosition: LogPosition.Exact
+)
+
+/**
+ * The [[LogPosition.Exact]] of the tombstone in the transaction log.
+ */
+final case class TombstoneResult(
+  logPosition: LogPosition.Exact
+)
+
+/**
+ * A subscription confirmation identifier as the first value from
+ * the EventStoreDB when subscribing to a stream. Not intended for
+ * public use.
+ */
+final private[sec] case class SubscriptionConfirmation(
+  id: String
+)

--- a/fs2/src/main/scala-3/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/metastreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Alex Henning Johannessen
+ * Copyright 2020 Scala EventStoreDB Client
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/gossip.scala
+++ b/fs2/src/main/scala/sec/api/gossip.scala
@@ -40,16 +40,6 @@ trait Gossip[F[_]] {
    * cluster information that requires different credentials from what is provided through
    * configuration.
    *
-   * ==Example using custom credentials==
-   *
-   * {{{
-   *  val clusterInfo: F[ClusterInfo] =
-   *    metaStreams.withCredentials(customCreds).read(id)
-   * }}}
-   *
-   * If the need for custom credentials is frequent you can define an extension method
-   * for [[read]] with an extra [[UserCredentials]] parameter.
-   *
    * @param creds Custom user credentials to use.
    */
   def withCredentials(creds: UserCredentials): Gossip[F]

--- a/fs2/src/main/scala/sec/api/metastreams.scala
+++ b/fs2/src/main/scala/sec/api/metastreams.scala
@@ -238,16 +238,6 @@ trait MetaStreams[F[_]] {
    * Returns an instance that uses provided [[UserCredentials]]. This is useful when an operation
    * requires different credentials from what is provided through configuration.
    *
-   * ==Example using custom credentials==
-   *
-   * {{{
-   *  val maxCount: F[Option[ReadResult[MaxCount]]] =
-   *    metaStreams.withCredentials(customCreds).getMaxCount(id)
-   * }}}
-   *
-   * If the need for custom credentials is frequent you can define extension methods
-   * for those opererations on [[MetaStreams]] with an extra [[UserCredentials]] parameter.
-   *
    * @param creds Custom user credentials to use.
    */
   def withCredentials(creds: UserCredentials): MetaStreams[F]

--- a/fs2/src/main/scala/sec/syntax/api.scala
+++ b/fs2/src/main/scala/sec/syntax/api.scala
@@ -34,17 +34,40 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
 
   /// Subscription
 
+  /**
+   * Subscribes to the global stream, [[StreamId.All]] without
+   * resolving [[EventType.LinkTo]] events.
+   *
+   * @param exclusiveFrom position to start from. Use [[None]] to subscribe from the beginning.
+   * @return a [[Stream]] that emits [[Event]] values.
+   */
   def subscribeToAll(
     exclusiveFrom: Option[LogPosition]
   ): Stream[F, Event] =
     s.subscribeToAll(exclusiveFrom, resolveLinkTos = false)
 
-  def subscribeToAllFiltered(
+  /**
+   * Subscribes to the global stream, [[StreamId.All]] using a subscription filter without
+   * resolving [[EventType.LinkTo]] events.
+   *
+   * @param exclusiveFrom log position to start from. Use [[None]] to subscribe from the beginning.
+   * @param filterOptions to use when subscribing - See [[sec.api.SubscriptionFilterOptions]].
+   * @return a [[Stream]] that emits either [[Checkpoint]] or [[Event]] values.
+   *         How frequent [[Checkpoint]] is emitted depends on [[filterOptions]].
+   */
+  def subscribeToAll(
     exclusiveFrom: Option[LogPosition],
     filterOptions: SubscriptionFilterOptions
   ): Stream[F, Either[Checkpoint, Event]] =
     s.subscribeToAll(exclusiveFrom, filterOptions, resolveLinkTos = false)
 
+  /**
+   * Subscribes to an individual stream without resolving [[EventType.LinkTo]] events.
+   *
+   * @param streamId the id of the stream to subscribe to.
+   * @param exclusiveFrom stream position to start from. Use [[None]] to subscribe from the beginning.
+   * @return a [[Stream]] that emits [[Event]] values.
+   */
   def subscribeToStream(
     streamId: StreamId,
     exclusiveFrom: Option[StreamPosition]
@@ -53,6 +76,46 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
 
   /// Read
 
+  /**
+   * Read events forwards from the global stream, [[sec.StreamId.All]].
+   *
+   * @param from log position to read from.
+   * @param maxCount limits maximum events returned.
+   * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
+   * @return a [[Stream]] that emits [[Event]] values.
+   */
+  def readAllForwards(
+    from: LogPosition = LogPosition.Start,
+    maxCount: Long = Long.MaxValue,
+    resolveLinkTos: Boolean = false
+  ): Stream[F, Event] =
+    s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos)
+
+  /**
+   * Read events backwards from the global stream, [[sec.StreamId.All]].
+   *
+   * @param from log position to read from.
+   * @param maxCount limits maximum events returned.
+   * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
+   * @return a [[Stream]] that emits [[Event]] values.
+   */
+  def readAllBackwards(
+    from: LogPosition = LogPosition.End,
+    maxCount: Long = Long.MaxValue,
+    resolveLinkTos: Boolean = false
+  ): Stream[F, Event] =
+    s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos)
+
+  /**
+   * Read events forwards from an individual stream. A [[sec.api.exceptions.StreamNotFound]] is raised
+   * when the stream does not exist.
+   *
+   * @param streamId the id of the stream to subscribe to.
+   * @param from stream position to read from.
+   * @param maxCount limits maximum events returned.
+   * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
+   * @return a [[Stream]] that emits [[Event]] values.
+   */
   def readStreamForwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.Start,
@@ -61,6 +124,16 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
   ): Stream[F, Event] =
     s.readStream(streamId, from, Direction.Forwards, maxCount, resolveLinkTos)
 
+  /**
+   * Read events backwards from an individual stream. A [[sec.api.exceptions.StreamNotFound]] is raised
+   * when the stream does not exist.
+   *
+   * @param streamId the id of the stream to subscribe to.
+   * @param from stream position to read from.
+   * @param maxCount limits maximum events returned.
+   * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
+   * @return a [[Stream]] that emits [[Event]] values.
+   */
   def readStreamBackwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.End,
@@ -68,20 +141,6 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     resolveLinkTos: Boolean = false
   ): Stream[F, Event] =
     s.readStream(streamId, from, Direction.Backwards, maxCount, resolveLinkTos)
-
-  def readAllForwards(
-    from: LogPosition = LogPosition.Start,
-    maxCount: Long = Long.MaxValue,
-    resolveLinkTos: Boolean = false
-  ): Stream[F, Event] =
-    s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos)
-
-  def readAllBackwards(
-    from: LogPosition = LogPosition.End,
-    maxCount: Long = Long.MaxValue,
-    resolveLinkTos: Boolean = false
-  ): Stream[F, Event] =
-    s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos)
 
 }
 

--- a/tests/src/sit/scala/sec/api/streams.scala
+++ b/tests/src/sit/scala/sec/api/streams.scala
@@ -205,8 +205,7 @@ class StreamsSuite extends SnSpec {
         def write(eds: Nel[EventData]) =
           eds.traverse(e => streams.appendToStream(mkStreamId, NoStream, Nel.one(e)))
 
-        val subscribe =
-          streams.subscribeToAllFiltered(from, options).takeThrough(_.fold(_ => true, _.eventData != after.last))
+        val subscribe = streams.subscribeToAll(from, options).takeThrough(_.fold(_ => true, _.eventData != after.last))
 
         val writeBefore = write(before).whenA(includeBefore).void
         val writeAfter  = write(after).void
@@ -248,7 +247,7 @@ class StreamsSuite extends SnSpec {
           eds.traverse(e => streams.appendToStream(mkStreamId, NoStream, Nel.one(e)))
 
         def subscribe(from: LogPosition) =
-          streams.subscribeToAllFiltered(from.some, options).takeThrough(_.fold(_ => true, _.eventData != after.last))
+          streams.subscribeToAll(from.some, options).takeThrough(_.fold(_ => true, _.eventData != after.last))
 
         val writeBefore = write(before).whenA(includeBefore).void
         val writeAfter  = write(after).void
@@ -1618,9 +1617,9 @@ class StreamsSuite extends SnSpec {
         for {
           wr  <- streams.appendToStream(id, StreamState.NoStream, events)
           pos <- streams.readStreamForwards(id, maxCount = 1).compile.lastOrError.map(_.logPosition)
-          dr  <- streams.tombstone(id, wr.streamPosition)
+          tr  <- streams.tombstone(id, wr.streamPosition)
 
-        } yield dr.logPosition > pos
+        } yield tr.logPosition > pos
 
       }
 

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -666,11 +666,13 @@ class StreamsMappingSpec extends mutable.Specification {
 
       mkDeleteResult[ErrorOr](s.DeleteResp().withNoPosition(empty)) shouldEqual
         ProtoResultError("Required value DeleteResp.PositionOptions.Position missing or invalid.").asLeft
+    }
 
-      mkDeleteResult[ErrorOr](s.TombstoneResp().withPosition(s.TombstoneResp.Position(1L, 1L))) shouldEqual
-        DeleteResult(sec.LogPosition.exact(1L, 1L)).asRight
+    "mkTombstoneResult" >> {
+      mkTombstoneResult[ErrorOr](s.TombstoneResp().withPosition(s.TombstoneResp.Position(1L, 1L))) shouldEqual
+        TombstoneResult(sec.LogPosition.exact(1L, 1L)).asRight
 
-      mkDeleteResult[ErrorOr](s.TombstoneResp().withNoPosition(empty)) shouldEqual
+      mkTombstoneResult[ErrorOr](s.TombstoneResp().withNoPosition(empty)) shouldEqual
         ProtoResultError("Required value TombstoneResp.PositionOptions.Position missing or invalid.").asLeft
     }
 

--- a/tests/src/test/scala/sec/api/streams.scala
+++ b/tests/src/test/scala/sec/api/streams.scala
@@ -17,22 +17,6 @@
 package sec
 package api
 
-/*
- * Copyright 2020 Alex Henning Johannessen
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 


### PR DESCRIPTION
 - more api docs for user facing types.
 - add concrete type for tombstone result.
 - remove redundant examples that are better
   to have in website docs.