### PR TITLE
all: account for esdb missing log pos on streams / rm show

### DIFF
--- a/core/src/main/scala/sec/api/endpoint.scala
+++ b/core/src/main/scala/sec/api/endpoint.scala
@@ -19,7 +19,7 @@ package api
 
 import java.net.InetSocketAddress
 
-import cats.{Order, Show}
+import cats.Order
 import io.grpc.{Attributes, EquivalentAddressGroup}
 
 /**
@@ -34,13 +34,16 @@ final case class Endpoint(
 
 object Endpoint {
 
+  final private val ae: Attributes = Attributes.EMPTY
+
   implicit val orderForEndpoint: Order[Endpoint]       = Order.by(ep => (ep.address, ep.port))
   implicit val orderingForEndpoint: Ordering[Endpoint] = orderForEndpoint.toOrdering
-  implicit val showForEndpoint: Show[Endpoint]         = Show.show(ep => s"${ep.address}:${ep.port}")
+
+  def render(ep: Endpoint): String = s"${ep.address}:${ep.port}"
 
   implicit final private[sec] class EndpointOps(val ep: Endpoint) extends AnyVal {
-    def toInetSocketAddress: InetSocketAddress = new InetSocketAddress(ep.address, ep.port)
-    def toEquivalentAddressGroup: EquivalentAddressGroup =
-      new EquivalentAddressGroup(ep.toInetSocketAddress, Attributes.EMPTY)
+    def render: String                                   = Endpoint.render(ep)
+    def toInetSocketAddress: InetSocketAddress           = new InetSocketAddress(ep.address, ep.port)
+    def toEquivalentAddressGroup: EquivalentAddressGroup = new EquivalentAddressGroup(ep.toInetSocketAddress, ae)
   }
 }

--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -63,7 +63,7 @@ object exceptions {
   object WrongExpectedState {
 
     def msg(sid: StreamId, expected: StreamState, actual: StreamState): String =
-      s"Wrong expected state for stream: ${sid.show}, expected: ${expected.show}, actual: ${actual.show}"
+      s"Wrong expected state for stream: ${sid.render}, expected: ${expected.render}, actual: ${actual.render}"
 
   }
 

--- a/core/src/main/scala/sec/id.scala
+++ b/core/src/main/scala/sec/id.scala
@@ -16,8 +16,8 @@
 
 package sec
 
+import cats.Eq
 import cats.syntax.all._
-import cats.{Eq, Show}
 import sec.utilities.{guardNonEmpty, guardNotStartsWith}
 
 //======================================================================================================================
@@ -107,7 +107,7 @@ object StreamId {
       }
 
     def stringValue: String     = streamIdToString(sid)
-    def show: String            = stringValue
+    def render: String          = stringValue
     def isNormal: Boolean       = fold(_ => true, _ => false, _ => false)
     def isSystemOrMeta: Boolean = fold(_ => false, _ => true, _ => true)
 
@@ -117,8 +117,8 @@ object StreamId {
     def metaId: MetaId = MetaId(id)
   }
 
-  implicit val eqForStreamId: Eq[StreamId]     = Eq.fromUniversalEquals[StreamId]
-  implicit val showForStreamId: Show[StreamId] = Show.show[StreamId](_.show)
+  implicit val eqForStreamId: Eq[StreamId] = Eq.fromUniversalEquals[StreamId]
+
 }
 
 //======================================================================================================================

--- a/core/src/main/scala/sec/package.scala
+++ b/core/src/main/scala/sec/package.scala
@@ -18,6 +18,11 @@ import cats.{ApplicativeError, MonadError}
 
 package object sec {
 
+  type AllEvent    = sec.Event[Position.All]
+  type StreamEvent = sec.Event[Position.Stream]
+
+  ///
+
   private[sec] type ErrorM[F[_]] = MonadError[F, Throwable]
   private[sec] type ErrorA[F[_]] = ApplicativeError[F, Throwable]
   private[sec] type Attempt[T]   = Either[String, T]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,7 +38,6 @@ In order to verify that you can reach the database try out the
 following [IOApp](https://typelevel.org/cats-effect/datatypes/ioapp.html):
 
 ```scala mdoc:compile-only
-import cats.syntax.all._
 import cats.effect._
 import sec.api._
 
@@ -47,7 +46,7 @@ object HelloWorld extends IOApp {
   def run(args: List[String]): IO[ExitCode] = EsClient
     .singleNode[IO]("127.0.0.1", 2113)
     .resource.use(client => 
-      client.gossip.read.flatMap(ci => IO(println(ci.show)))
+      client.gossip.read.map(_.render).flatMap(str => IO(println(str)))
     )
     .as(ExitCode.Success)
 

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -40,7 +40,7 @@ object WritingEvents extends IOApp {
       streamId <- mkStreamId
       data     <- NonEmptyList.of(eventData1, eventData2).sequence
       _        <- streams.appendToStream(streamId, StreamState.NoStream, data)
-      _        <- streams.readStreamForwards(streamId).debug(_.show).compile.drain
+      _        <- streams.readStreamForwards(streamId).debug(_.render).compile.drain
     } yield ()
   }
 

--- a/fs2/src/main/scala/sec/syntax/api.scala
+++ b/fs2/src/main/scala/sec/syntax/api.scala
@@ -39,11 +39,11 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    * resolving [[EventType.LinkTo]] events.
    *
    * @param exclusiveFrom position to start from. Use [[None]] to subscribe from the beginning.
-   * @return a [[Stream]] that emits [[Event]] values.
+   * @return a [[Stream]] that emits [[AllEvent]] values.
    */
   def subscribeToAll(
     exclusiveFrom: Option[LogPosition]
-  ): Stream[F, Event] =
+  ): Stream[F, AllEvent] =
     s.subscribeToAll(exclusiveFrom, resolveLinkTos = false)
 
   /**
@@ -52,13 +52,13 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    *
    * @param exclusiveFrom log position to start from. Use [[None]] to subscribe from the beginning.
    * @param filterOptions to use when subscribing - See [[sec.api.SubscriptionFilterOptions]].
-   * @return a [[Stream]] that emits either [[Checkpoint]] or [[Event]] values.
+   * @return a [[Stream]] that emits either [[Checkpoint]] or [[AllEvent]] values.
    *         How frequent [[Checkpoint]] is emitted depends on [[filterOptions]].
    */
   def subscribeToAll(
     exclusiveFrom: Option[LogPosition],
     filterOptions: SubscriptionFilterOptions
-  ): Stream[F, Either[Checkpoint, Event]] =
+  ): Stream[F, Either[Checkpoint, AllEvent]] =
     s.subscribeToAll(exclusiveFrom, filterOptions, resolveLinkTos = false)
 
   /**
@@ -66,12 +66,12 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    *
    * @param streamId the id of the stream to subscribe to.
    * @param exclusiveFrom stream position to start from. Use [[None]] to subscribe from the beginning.
-   * @return a [[Stream]] that emits [[Event]] values.
+   * @return a [[Stream]] that emits [[StreamEvent]] values.
    */
   def subscribeToStream(
     streamId: StreamId,
     exclusiveFrom: Option[StreamPosition]
-  ): Stream[F, Event] =
+  ): Stream[F, StreamEvent] =
     s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos = false)
 
   /// Read
@@ -82,13 +82,13 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    * @param from log position to read from.
    * @param maxCount limits maximum events returned.
    * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
-   * @return a [[Stream]] that emits [[Event]] values.
+   * @return a [[Stream]] that emits [[AllEvent]] values.
    */
   def readAllForwards(
     from: LogPosition = LogPosition.Start,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, Event] =
+  ): Stream[F, AllEvent] =
     s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos)
 
   /**
@@ -97,13 +97,13 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    * @param from log position to read from.
    * @param maxCount limits maximum events returned.
    * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
-   * @return a [[Stream]] that emits [[Event]] values.
+   * @return a [[Stream]] that emits [[AllEvent]] values.
    */
   def readAllBackwards(
     from: LogPosition = LogPosition.End,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, Event] =
+  ): Stream[F, AllEvent] =
     s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos)
 
   /**
@@ -114,14 +114,14 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    * @param from stream position to read from.
    * @param maxCount limits maximum events returned.
    * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
-   * @return a [[Stream]] that emits [[Event]] values.
+   * @return a [[Stream]] that emits [[StreamEvent]] values.
    */
   def readStreamForwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.Start,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, Event] =
+  ): Stream[F, StreamEvent] =
     s.readStream(streamId, from, Direction.Forwards, maxCount, resolveLinkTos)
 
   /**
@@ -132,14 +132,14 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
    * @param from stream position to read from.
    * @param maxCount limits maximum events returned.
    * @param resolveLinkTos whether to resolve [[EventType.LinkTo]] events automatically.
-   * @return a [[Stream]] that emits [[Event]] values.
+   * @return a [[Stream]] that emits [[StreamEvent]] values.
    */
   def readStreamBackwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.End,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, Event] =
+  ): Stream[F, StreamEvent] =
     s.readStream(streamId, from, Direction.Backwards, maxCount, resolveLinkTos)
 
 }

--- a/tests/src/cit/scala/sec/api/cluster.scala
+++ b/tests/src/cit/scala/sec/api/cluster.scala
@@ -19,8 +19,6 @@ package api
 
 import scala.concurrent.duration._
 
-import cats.implicits._
-
 class ClusterSuite extends CSpec {
 
   "Cluster" should {
@@ -29,7 +27,7 @@ class ClusterSuite extends CSpec {
 
       fs2.Stream
         .eval(gossip.read)
-        .evalTap(x => log.info(s"Gossip.read: ${x.show}"))
+        .evalTap(x => log.info(s"Gossip.read: ${x.render}"))
         .metered(150.millis)
         .repeat
         .take(5)

--- a/tests/src/test/scala/sec/api/endpoint.scala
+++ b/tests/src/test/scala/sec/api/endpoint.scala
@@ -18,7 +18,6 @@ package sec
 package api
 
 import cats.kernel.laws.discipline._
-import cats.syntax.all._
 import org.scalacheck._
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
@@ -33,8 +32,8 @@ class EndpointSpec extends Specification with Discipline {
       checkAll("Endpoint", OrderTests[Endpoint].order)
     }
 
-    "show" >> {
-      Endpoint("127.0.0.1", 2113).show shouldEqual "127.0.0.1:2113"
+    "render" >> {
+      Endpoint("127.0.0.1", 2113).render shouldEqual "127.0.0.1:2113"
     }
   }
 

--- a/tests/src/test/scala/sec/api/gossip.scala
+++ b/tests/src/test/scala/sec/api/gossip.scala
@@ -21,7 +21,6 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 import cats.kernel.laws.discipline._
-import cats.syntax.all._
 import org.scalacheck._
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
@@ -38,7 +37,7 @@ class GossipSpec extends Specification with Discipline {
         checkAll("ClusterInfo", OrderTests[ClusterInfo].eqv)
       }
 
-      "show" >> {
+      "render" >> {
 
         val m1 = MemberInfo(
           UUID.fromString("a781aa1f-0b48-47dd-84e1-519bdd1dcc6c"),
@@ -66,7 +65,7 @@ class GossipSpec extends Specification with Discipline {
 
         val ci = ClusterInfo(Set(m1, m2, m3))
 
-        ci.show shouldEqual
+        ci.render shouldEqual
           """ClusterInfo:
             | ✔ Leader   127.0.0.1:2113 2020-07-27T16:20:34Z a781aa1f-0b48-47dd-84e1-519bdd1dcc6c
             | ✕ Follower 127.0.0.2:2113 2020-07-27T16:20:34Z 7342793a-25cc-48b2-97fe-cd0779c043f3
@@ -83,7 +82,7 @@ class GossipSpec extends Specification with Discipline {
         checkAll("MemberInfo", OrderTests[MemberInfo].order)
       }
 
-      "show" >> {
+      "render" >> {
 
         val m1 = MemberInfo(
           UUID.fromString("a781aa1f-0b48-47dd-84e1-519bdd1dcc6c"),
@@ -101,8 +100,8 @@ class GossipSpec extends Specification with Discipline {
           Endpoint("127.0.0.2", 2113)
         )
 
-        m1.show shouldEqual s"✔ Follower 127.0.0.1:2113 2020-07-27T16:20:34Z a781aa1f-0b48-47dd-84e1-519bdd1dcc6c"
-        m2.show shouldEqual s"✕ Leader 127.0.0.2:2113 2020-07-27T16:20:34Z 7f1ae876-d9d0-4441-b6c0-c5962e330dc6"
+        m1.render shouldEqual s"✔ Follower 127.0.0.1:2113 2020-07-27T16:20:34Z a781aa1f-0b48-47dd-84e1-519bdd1dcc6c"
+        m2.render shouldEqual s"✕ Leader 127.0.0.2:2113 2020-07-27T16:20:34Z 7f1ae876-d9d0-4441-b6c0-c5962e330dc6"
       }
     }
 
@@ -113,8 +112,8 @@ class GossipSpec extends Specification with Discipline {
         checkAll("VNodeState", OrderTests[VNodeState].order)
       }
 
-      "show" >> {
-        VNodeState.values.map(_.toString) shouldEqual VNodeState.values.map(_.show)
+      "render" >> {
+        VNodeState.values.map(_.toString) shouldEqual VNodeState.values.map(_.render)
       }
     }
 

--- a/tests/src/test/scala/sec/id.scala
+++ b/tests/src/test/scala/sec/id.scala
@@ -64,9 +64,9 @@ class StreamIdSpec extends Specification with Discipline {
     StreamId.stringToStreamId(normal.stringValue) should beRight(normal)
   }
 
-  "show" >> {
+  "render" >> {
     val sid = sampleOf[StreamId]
-    sid.show shouldEqual sid.stringValue
+    sid.render shouldEqual sid.stringValue
   }
 
   "StreamIdOps" >> {
@@ -104,7 +104,7 @@ class StreamIdSpec extends Specification with Discipline {
   }
 
   "Eq" >> {
-    implicit val cogen: Cogen[StreamId] = Cogen[String].contramap[StreamId](_.show)
+    implicit val cogen: Cogen[StreamId] = Cogen[String].contramap[StreamId](_.stringValue)
     checkAll("StreamId", EqTests[StreamId].eqv)
   }
 

--- a/tests/src/test/scala/sec/metadata.scala
+++ b/tests/src/test/scala/sec/metadata.scala
@@ -104,11 +104,11 @@ class MetaStateSpec extends Specification {
 
   }
 
-  "show" >> {
+  "render" >> {
 
     MetaState.empty
       .copy(maxAge = MaxAge(10.days).toOption, maxCount = MaxCount(1).toOption)
-      .show shouldEqual s"""
+      .render shouldEqual s"""
        |MetaState:
        |  max-age         = 10 days
        |  max-count       = 1 event
@@ -123,7 +123,7 @@ class MetaStateSpec extends Specification {
       cacheControl   = CacheControl(12.hours).toOption,
       truncateBefore = StreamPosition.exact(1000L).some,
       acl            = StreamAcl.empty.copy(readRoles = Set("a", "b")).some
-    ).show shouldEqual s"""
+    ).render shouldEqual s"""
        |MetaState:
        |  max-age         = n/a
        |  max-count       = 50 events
@@ -132,7 +132,7 @@ class MetaStateSpec extends Specification {
        |  access-list     = read: [a, b], write: [], delete: [], meta-read: [], meta-write: []
        |""".stripMargin
 
-    MetaState.empty.show shouldEqual s"""
+    MetaState.empty.render shouldEqual s"""
        |MetaState:
        |  max-age         = n/a
        |  max-count       = n/a
@@ -185,10 +185,10 @@ class StreamAclSpec extends Specification {
 
   }
 
-  "show" >> {
+  "render" >> {
     StreamAcl.empty
       .copy(readRoles = Set("a", "b"), Set("b"))
-      .show shouldEqual "read: [a, b], write: [b], delete: [], meta-read: [], meta-write: []"
+      .render shouldEqual "read: [a, b], write: [b], delete: [], meta-read: [], meta-write: []"
   }
 
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   themeConfig: {
     sidebarCollapsible: false,
     colorMode: {
-      defaultMode: 'light',
+      defaultMode: 'dark',
       respectPrefersColorScheme: true
     },
     navbar: {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -59,7 +59,6 @@ function Home() {
   const {siteConfig = {}} = context;
   return (
     <Layout
-      title={siteConfig.title}
       description={siteConfig.tagline}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -28,6 +28,7 @@
 
 .features {
   display: flex;
+  text-align: center;
   align-items: center;
   padding: 2rem 0;
   width: 100%;


### PR DESCRIPTION
all:
 - change `Event` to account for different kind of position
   information available depending on whether events arrive
   from the all stream or individual streams.

 - add `Position` type that has two variants for position
   information.

 - adjust mappings and pipes for `Streams`.

 - add and adjust tests.

misc: 
 - replace `show` with `render` method.