### PR TITLE
build: move to Scala3-M3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.0-M2, 2.13.4]
+        scala: [3.0.0-M3, 2.13.4]
         java: [adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -131,12 +131,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.0.0-M2)
+      - name: Download target directories (3.0.0-M3)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.0.0-M2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.0.0-M3-${{ matrix.java }}
 
-      - name: Inflate target directories (3.0.0-M2)
+      - name: Inflate target directories (3.0.0-M3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 lazy val Scala2 = "2.13.4"
-lazy val Scala3 = "3.0.0-M2"
+lazy val Scala3 = "3.0.0-M3"
 
 lazy val sec = project
   .in(file("."))
@@ -103,6 +103,11 @@ lazy val commonSettings = Seq(
   scalacOptions ++= {
     if (isDotty.value) Seq("-source:3.0-migration") else Nil
   },
+  scalacOptions := {
+    if (isDotty.value)
+      scalacOptions.value.filterNot(_ == "-Xfatal-warnings") // TODO: Remove when ScalaPB avoids auto insertion of apply
+    else scalacOptions.value
+  },
   Compile / doc / sources := {
     val old = (Compile / doc / sources).value
     if (isDotty.value) Nil else old
@@ -115,7 +120,7 @@ inThisBuild(
   List(
     scalaVersion := crossScalaVersions.value.last,
     crossScalaVersions := Seq(Scala3, Scala2),
-    scalacOptions ++= Seq("-target:jvm-1.8"),
+    scalacOptions ++= Seq("target:8"),
     javacOptions ++= Seq("-target", "8", "-source", "8"),
     organization := "io.github.ahjohannessen",
     organizationName := "Scala EventStoreDB Client",


### PR DESCRIPTION
 - temporary disable fatal warnings when Scala3
   due to ScalaPB generating code that requires
   auto insertion of apply.