### PR TITLE
all: misc minor improvements

### DIFF
--- a/.docker/cluster.ci.yml
+++ b/.docker/cluster.ci.yml
@@ -6,7 +6,7 @@ x-common-variables: &common-variables
 services:
 
   es1:
-    image: eventstore/eventstore:21.2.0-bionic
+    image: eventstore/eventstore:21.6.0-bionic
     env_file:
       - ./shared.env
     environment:
@@ -24,7 +24,7 @@ services:
       - cert-gen
 
   es2:
-    image: eventstore/eventstore:21.2.0-bionic
+    image: eventstore/eventstore:21.6.0-bionic
     env_file:
       - ./shared.env
     environment:
@@ -42,7 +42,7 @@ services:
       - cert-gen
 
   es3:
-    image: eventstore/eventstore:21.2.0-bionic
+    image: eventstore/eventstore:21.6.0-bionic
     env_file:
       - ./shared.env
     environment:

--- a/.docker/single-node.ci.yml
+++ b/.docker/single-node.ci.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   es:
-    image: eventstore/eventstore:21.2.0-bionic
+    image: eventstore/eventstore:21.6.0-bionic
     env_file:
       - ./shared.env
     environment:

--- a/core/src/main/scala/sec/api/grpc/convert.scala
+++ b/core/src/main/scala/sec/api/grpc/convert.scala
@@ -82,7 +82,8 @@ private[sec] object convert {
   }
 
   val serverUnavailable: StatusRuntimeException => Option[ServerUnavailable] = { ex =>
-    Option.when(ex.getStatus.getCode == Status.Code.UNAVAILABLE)(ServerUnavailable(ex.getMessage))
+    val cause = Option(ex.getCause()).fold("")(c => s", cause: ${c.getMessage}")
+    Option.when(ex.getStatus.getCode == Status.Code.UNAVAILABLE)(ServerUnavailable(s"${ex.getMessage}$cause"))
   }
 
 //======================================================================================================================

--- a/core/src/main/scala/sec/api/mapping/gossip.scala
+++ b/core/src/main/scala/sec/api/mapping/gossip.scala
@@ -18,6 +18,7 @@ package sec
 package api
 package mapping
 
+import cats.MonadThrow
 import cats.syntax.all._
 import com.eventstore.dbclient.proto.{gossip => p}
 import sec.api.mapping.implicits._
@@ -51,7 +52,7 @@ private[sec] object gossip {
 
   }
 
-  def mkMemberInfo[F[_]: ErrorM](mi: p.MemberInfo): F[MemberInfo] = {
+  def mkMemberInfo[F[_]: MonadThrow](mi: p.MemberInfo): F[MemberInfo] = {
 
     val instanceId = mi.instanceId.require[F]("instanceId") >>= mkJuuid[F]
     val timestamp  = fromTicksSinceEpoch[F](mi.timeStamp)
@@ -64,7 +65,7 @@ private[sec] object gossip {
     }
   }
 
-  def mkClusterInfo[F[_]: ErrorM](ci: p.ClusterInfo): F[ClusterInfo] =
+  def mkClusterInfo[F[_]: MonadThrow](ci: p.ClusterInfo): F[ClusterInfo] =
     ci.members.toList.traverse(mkMemberInfo[F]).map(m => ClusterInfo(m.toSet))
 
 }

--- a/core/src/main/scala/sec/api/mapping/implicits.scala
+++ b/core/src/main/scala/sec/api/mapping/implicits.scala
@@ -18,6 +18,7 @@ package sec
 package api
 package mapping
 
+import cats.ApplicativeThrow
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import scodec.bits.ByteVector
@@ -36,9 +37,9 @@ private[sec] object implicits {
 
   implicit final class OptionOps[A](private val o: Option[A]) extends AnyVal {
 
-    def require[F[_]: ErrorA](value: String): F[A] = require[F](value, None)
+    def require[F[_]: ApplicativeThrow](value: String): F[A] = require[F](value, None)
 
-    def require[F[_]: ErrorA](value: String, details: Option[String]) = {
+    def require[F[_]: ApplicativeThrow](value: String, details: Option[String]) = {
       def extra = details.map(d => s" $d").getOrElse("")
       def msg   = s"Required value $value missing or invalid.$extra"
       o.toRight(ProtoResultError(msg)).liftTo[F]

--- a/core/src/main/scala/sec/api/mapping/shared.scala
+++ b/core/src/main/scala/sec/api/mapping/shared.scala
@@ -19,7 +19,7 @@ package api
 package mapping
 
 import java.util.{UUID => JUUID}
-
+import cats.{ApplicativeThrow, MonadThrow}
 import cats.syntax.all._
 import com.eventstore.dbclient.proto.shared.{StreamIdentifier, UUID}
 import com.google.protobuf.ByteString
@@ -30,7 +30,7 @@ private[sec] object shared {
   val mkUuid: JUUID => UUID = j =>
     UUID().withStructured(UUID.Structured(j.getMostSignificantBits(), j.getLeastSignificantBits()))
 
-  def mkJuuid[F[_]: ErrorA](uuid: UUID): F[JUUID] = {
+  def mkJuuid[F[_]: ApplicativeThrow](uuid: UUID): F[JUUID] = {
 
     val juuid = uuid.value match {
       case UUID.Value.Structured(v) => new JUUID(v.mostSignificantBits, v.leastSignificantBits).asRight
@@ -43,10 +43,10 @@ private[sec] object shared {
 
   //
 
-  def mkStreamId[F[_]: ErrorM](sid: Option[StreamIdentifier]): F[StreamId] =
+  def mkStreamId[F[_]: MonadThrow](sid: Option[StreamIdentifier]): F[StreamId] =
     mkStreamId[F](sid.getOrElse(StreamIdentifier()))
 
-  def mkStreamId[F[_]: ErrorM](sid: StreamIdentifier): F[StreamId] =
+  def mkStreamId[F[_]: MonadThrow](sid: StreamIdentifier): F[StreamId] =
     sid.utf8[F] >>= { sidStr =>
       StreamId.stringToStreamId(sidStr).leftMap(ProtoResultError(_)).liftTo[F]
     }
@@ -60,7 +60,7 @@ private[sec] object shared {
   }
 
   implicit final class StreamIdentifierOps(val v: StreamIdentifier) extends AnyVal {
-    def utf8[F[_]](implicit F: ErrorA[F]): F[String] =
+    def utf8[F[_]](implicit F: ApplicativeThrow[F]): F[String] =
       F.catchNonFatal(Option(v.streamName.toStringUtf8()).getOrElse(""))
   }
 

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -18,6 +18,7 @@ package sec
 package api
 package mapping
 
+import cats.{ApplicativeThrow, MonadThrow}
 import cats.data.{NonEmptyList, OptionT}
 import cats.syntax.all._
 import com.eventstore.dbclient.proto.shared._
@@ -223,22 +224,22 @@ private[sec] object streams {
 
   object incoming {
 
-    def mkPositionGlobal[F[_]: ErrorA](e: ReadResp.ReadEvent.RecordedEvent): F[PositionInfo.Global] =
+    def mkPositionGlobal[F[_]: ApplicativeThrow](e: ReadResp.ReadEvent.RecordedEvent): F[PositionInfo.Global] =
       (mkStreamPosition[F](e), mkLogPosition[F](e)).mapN(PositionInfo.Global.apply)
 
-    def mkLogPosition[F[_]: ErrorA](e: ReadResp.ReadEvent.RecordedEvent): F[LogPosition.Exact] =
+    def mkLogPosition[F[_]: ApplicativeThrow](e: ReadResp.ReadEvent.RecordedEvent): F[LogPosition.Exact] =
       LogPosition(e.commitPosition, e.preparePosition).liftTo[F]
 
-    def mkStreamPosition[F[_]: ErrorA](e: ReadResp.ReadEvent.RecordedEvent): F[StreamPosition.Exact] =
+    def mkStreamPosition[F[_]: ApplicativeThrow](e: ReadResp.ReadEvent.RecordedEvent): F[StreamPosition.Exact] =
       StreamPosition(e.streamRevision).liftTo[F]
 
-    def mkCheckpoint[F[_]: ErrorA](c: ReadResp.Checkpoint): F[Checkpoint] =
+    def mkCheckpoint[F[_]: ApplicativeThrow](c: ReadResp.Checkpoint): F[Checkpoint] =
       LogPosition(c.commitPosition, c.preparePosition)
         .map(Checkpoint(_))
         .leftMap(error => ProtoResultError(s"Invalid position for Checkpoint: ${error.msg}"))
         .liftTo[F]
 
-    def mkCheckpointOrEvent[F[_]: ErrorM](re: ReadResp): F[Option[Either[Checkpoint, AllEvent]]] = {
+    def mkCheckpointOrEvent[F[_]: MonadThrow](re: ReadResp): F[Option[Either[Checkpoint, AllEvent]]] = {
 
       val mkEvt      = mkEvent[F, PositionInfo.Global](_, mkPositionGlobal[F])
       val event      = OptionT(re.content.event.flatTraverse(mkEvt).nested.map(_.asRight[Checkpoint]).value)
@@ -247,30 +248,30 @@ private[sec] object streams {
       (event <+> checkpoint).value
     }
 
-    def mkStreamNotFound[F[_]: ErrorM](snf: ReadResp.StreamNotFound): F[StreamNotFound] =
+    def mkStreamNotFound[F[_]: MonadThrow](snf: ReadResp.StreamNotFound): F[StreamNotFound] =
       snf.streamIdentifier.require[F]("StreamIdentifer") >>= (_.utf8[F].map(StreamNotFound(_)))
 
-    def failStreamNotFound[F[_]: ErrorM](rr: ReadResp): F[ReadResp] =
+    def failStreamNotFound[F[_]: MonadThrow](rr: ReadResp): F[ReadResp] =
       rr.content.streamNotFound.fold(rr.pure[F])(mkStreamNotFound[F](_) >>= (_.raiseError[F, ReadResp]))
 
-    def reqReadAll[F[_]: ErrorM](rr: ReadResp): F[Option[AllEvent]] =
+    def reqReadAll[F[_]: MonadThrow](rr: ReadResp): F[Option[AllEvent]] =
       reqReadEvent(rr, mkPositionGlobal[F])
 
-    def reqReadStream[F[_]: ErrorM](rr: ReadResp): F[Option[StreamEvent]] =
+    def reqReadStream[F[_]: MonadThrow](rr: ReadResp): F[Option[StreamEvent]] =
       reqReadEvent(rr, mkStreamPosition[F])
 
-    def reqReadEvent[F[_]: ErrorM, P <: PositionInfo](
+    def reqReadEvent[F[_]: MonadThrow, P <: PositionInfo](
       rr: ReadResp,
       mkPos: ReadResp.ReadEvent.RecordedEvent => F[P]): F[Option[Event[P]]] =
       rr.content.event.require[F]("ReadEvent") >>= (mkEvent[F, P](_, mkPos))
 
-    def reqConfirmation[F[_]: ErrorA](rr: ReadResp): F[SubscriptionConfirmation] =
+    def reqConfirmation[F[_]: ApplicativeThrow](rr: ReadResp): F[SubscriptionConfirmation] =
       rr.content.confirmation
         .map(_.subscriptionId)
         .require[F]("SubscriptionConfirmation", details = s"Got ${rr.content} instead".some)
         .map(SubscriptionConfirmation(_))
 
-    def mkEvent[F[_]: ErrorM, P <: PositionInfo](
+    def mkEvent[F[_]: MonadThrow, P <: PositionInfo](
       re: ReadResp.ReadEvent,
       mkPos: ReadResp.ReadEvent.RecordedEvent => F[P]
     ): F[Option[Event[P]]] =
@@ -280,7 +281,7 @@ private[sec] object streams {
           .map(lOpt => eOpt.map(er => lOpt.fold[Event[P]](er)(ResolvedEvent[P](er, _))))
       }
 
-    def mkEventRecord[F[_]: ErrorM, P <: PositionInfo](
+    def mkEventRecord[F[_]: MonadThrow, P <: PositionInfo](
       e: ReadResp.ReadEvent.RecordedEvent,
       mkPos: ReadResp.ReadEvent.RecordedEvent => F[P]): F[EventRecord[P]] = {
 
@@ -298,17 +299,17 @@ private[sec] object streams {
 
     }
 
-    def mkContentType[F[_]](ct: String)(implicit F: ErrorA[F]): F[ContentType] =
+    def mkContentType[F[_]](ct: String)(implicit F: ApplicativeThrow[F]): F[ContentType] =
       ct match {
         case ContentTypes.ApplicationOctetStream => F.pure(sec.ContentType.Binary)
         case ContentTypes.ApplicationJson        => F.pure(sec.ContentType.Json)
         case unknown => F.raiseError(ProtoResultError(s"Required value $ContentType missing or invalid: $unknown"))
       }
 
-    def mkEventType[F[_]: ErrorA](name: String): F[EventType] =
+    def mkEventType[F[_]: ApplicativeThrow](name: String): F[EventType] =
       EventType.stringToEventType(Option(name).getOrElse("")).leftMap(ProtoResultError(_)).liftTo[F]
 
-    def mkWriteResult[F[_]: ErrorA](sid: StreamId, ar: AppendResp): F[WriteResult] = {
+    def mkWriteResult[F[_]: ApplicativeThrow](sid: StreamId, ar: AppendResp): F[WriteResult] = {
 
       import AppendResp.{Result, Success}
       import AppendResp.WrongExpectedVersion.ExpectedRevisionOption
@@ -363,12 +364,12 @@ private[sec] object streams {
       result.liftTo[F]
     }
 
-    def mkDeleteResult[F[_]: ErrorA](dr: DeleteResp): F[DeleteResult] =
+    def mkDeleteResult[F[_]: ApplicativeThrow](dr: DeleteResp): F[DeleteResult] =
       dr.positionOption.position
         .map(p => DeleteResult(LogPosition.exact(p.commitPosition, p.preparePosition)))
         .require[F]("DeleteResp.PositionOptions.Position")
 
-    def mkTombstoneResult[F[_]: ErrorA](tr: TombstoneResp): F[TombstoneResult] =
+    def mkTombstoneResult[F[_]: ApplicativeThrow](tr: TombstoneResp): F[TombstoneResult] =
       tr.positionOption.position
         .map(p => TombstoneResult(LogPosition.exact(p.commitPosition, p.preparePosition)))
         .require[F]("TombstoneResp.PositionOptions.Position")

--- a/core/src/main/scala/sec/api/mapping/time.scala
+++ b/core/src/main/scala/sec/api/mapping/time.scala
@@ -19,7 +19,7 @@ package api
 package mapping
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
-
+import cats.ApplicativeThrow
 import cats.syntax.all._
 
 private[sec] object time {
@@ -27,7 +27,7 @@ private[sec] object time {
   /** @param value
     *   100-nanosecond intervals elapsed since 1970-01-01T00:00:00Z
     */
-  def fromTicksSinceEpoch[F[_]: ErrorA](value: Long): F[ZonedDateTime] = {
+  def fromTicksSinceEpoch[F[_]: ApplicativeThrow](value: Long): F[ZonedDateTime] = {
 
     val unitsPerSecond = 10000000L
     val seconds        = value / unitsPerSecond

--- a/core/src/main/scala/sec/metadata.scala
+++ b/core/src/main/scala/sec/metadata.scala
@@ -17,8 +17,7 @@
 package sec
 
 import scala.concurrent.duration._
-
-import cats.Endo
+import cats.{ApplicativeThrow, Endo}
 import cats.syntax.all._
 import io.circe.Decoder.Result
 import io.circe._
@@ -65,13 +64,13 @@ private[sec] object StreamMetadata {
 
     ///
 
-    def getCustom[F[_]: ErrorA, T: Decoder]: F[Option[T]] =
+    def getCustom[F[_]: ApplicativeThrow, T: Decoder]: F[Option[T]] =
       sm.custom.traverse(jo => Decoder[T].apply(Json.fromJsonObject(jo).hcursor).liftTo[F])
 
     def setCustom[T: Encoder.AsObject](custom: T): StreamMetadata =
       sm.withCustom(Encoder.AsObject[T].encodeObject(custom))
 
-    def modifyCustom[F[_]: ErrorA, T: Codec.AsObject](fn: Endo[Option[T]]): F[StreamMetadata] =
+    def modifyCustom[F[_]: ApplicativeThrow, T: Codec.AsObject](fn: Endo[Option[T]]): F[StreamMetadata] =
       getCustom[F, T].map(c => sm.setCustom(fn(c).map(Encoder.AsObject[T].encodeObject)))
 
   }

--- a/core/src/main/scala/sec/package.scala
+++ b/core/src/main/scala/sec/package.scala
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import cats.{ApplicativeError, MonadError}
-
 package object sec {
 
   type AllEvent    = sec.Event[PositionInfo.Global]
@@ -23,9 +21,7 @@ package object sec {
 
   ///
 
-  private[sec] type ErrorM[F[_]] = MonadError[F, Throwable]
-  private[sec] type ErrorA[F[_]] = ApplicativeError[F, Throwable]
-  private[sec] type Attempt[T]   = Either[String, T]
-  private[sec] type ErrorOr[T]   = Either[Throwable, T]
+  private[sec] type Attempt[T] = Either[String, T]
+  private[sec] type ErrorOr[T] = Either[Throwable, T]
 
 }

--- a/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
@@ -18,7 +18,7 @@ package sec
 package syntax
 
 import scala.concurrent.duration.FiniteDuration
-
+import cats.MonadThrow
 import cats.syntax.all._
 import sec.api._
 
@@ -26,11 +26,11 @@ import StreamId.Id
 
 trait MetaStreamsSyntax {
 
-  implicit final def syntaxForMetaStreams[F[_]: ErrorM](ms: MetaStreams[F]): MetaStreamsOps[F] =
+  implicit final def syntaxForMetaStreams[F[_]: MonadThrow](ms: MetaStreams[F]): MetaStreamsOps[F] =
     new MetaStreamsOps[F](ms)
 }
 
-final class MetaStreamsOps[F[_]: ErrorM](val ms: MetaStreams[F]) {
+final class MetaStreamsOps[F[_]: MonadThrow](val ms: MetaStreams[F]) {
 
   /** Sets max age in [[FiniteDuration]] for a stream and returns [[WriteResult]] with current positions of the stream
     * after a successful operation. Failure to fulfill the expected state is manifested by raising

--- a/fs2/src/main/scala-2.13/sec/syntax/std.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/std.scala
@@ -17,6 +17,7 @@
 package sec
 package syntax
 
+import cats.ApplicativeThrow
 import cats.syntax.all._
 import scodec.bits.ByteVector
 
@@ -25,5 +26,5 @@ trait StringSyntax {
 }
 
 final class StringOps(val s: String) extends AnyVal {
-  def utf8Bytes[F[_]: ErrorA]: F[ByteVector] = ByteVector.encodeUtf8(s).liftTo[F]
+  def utf8Bytes[F[_]: ApplicativeThrow]: F[ByteVector] = ByteVector.encodeUtf8(s).liftTo[F]
 }

--- a/fs2/src/main/scala-3/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/metastreams.scala
@@ -18,13 +18,14 @@ package sec
 package syntax
 
 import scala.concurrent.duration.FiniteDuration
+import cats.MonadThrow
 import cats.syntax.all._
 import sec.api._
 import StreamId.Id
 
 trait MetaStreamsSyntax {
 
-  extension [F[_]: ErrorM](ms: MetaStreams[F]) {
+  extension [F[_]: MonadThrow](ms: MetaStreams[F]) {
 
     /** Sets max age in [[FiniteDuration]] for a stream and returns [[WriteResult]] with current positions of the stream
       * after a successful operation. Failure to fulfill the expected state is manifested by raising

--- a/fs2/src/main/scala-3/sec/syntax/std.scala
+++ b/fs2/src/main/scala-3/sec/syntax/std.scala
@@ -17,12 +17,13 @@
 package sec
 package syntax
 
+import cats.ApplicativeThrow
 import cats.syntax.all._
 import scodec.bits.ByteVector
 
 trait StringSyntax {
 
-  extension [F[_]: ErrorA](s: String) {
+  extension [F[_]: ApplicativeThrow](s: String) {
 
     def utf8Bytes: F[ByteVector] = ByteVector.encodeUtf8(s).liftTo[F]
 

--- a/fs2/src/main/scala/sec/api/metastreams.scala
+++ b/fs2/src/main/scala/sec/api/metastreams.scala
@@ -19,7 +19,7 @@ package api
 
 import java.{util => ju}
 
-import cats.Endo
+import cats.{ApplicativeThrow, Endo}
 import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.syntax.all._
@@ -381,7 +381,7 @@ object MetaStreams {
   private[sec] val printer: Printer             = Printer.noSpaces.copy(dropNullValues = true)
   private[sec] def uuid[F[_]: Sync]: F[ju.UUID] = Sync[F].delay(ju.UUID.randomUUID())
 
-  private[sec] def mkEventData[F[_]: ErrorA](eventId: ju.UUID, sm: StreamMetadata): F[EventData] =
+  private[sec] def mkEventData[F[_]: ApplicativeThrow](eventId: ju.UUID, sm: StreamMetadata): F[EventData] =
     ByteVector
       .encodeUtf8(printer.print(Encoder[StreamMetadata].apply(sm)))
       .map(EventData(EventType.StreamMetadata, eventId, _, ContentType.Json))

--- a/tests/src/cit/resources/logback.xml
+++ b/tests/src/cit/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/tests/src/cit/scala/sec/api/spec.scala
+++ b/tests/src/cit/scala/sec/api/spec.scala
@@ -18,16 +18,15 @@ package sec
 package api
 
 import java.io.File
-
 import scala.concurrent.duration._
-
 import cats.data.NonEmptySet
 import cats.effect._
 import org.typelevel.log4cats.Logger
-
 import helpers.endpoint.endpointFrom
+import org.specs2.specification.Retries
 
-trait CSpec extends ClientSpec {
+trait CSpec extends ClientSpec with Retries {
+  override def sleep: Duration                       = 500.millis
   final val makeResource: Resource[IO, EsClient[IO]] = CSpec.mkClient[IO](log)
 }
 

--- a/tests/src/test/scala/sec/api/cluster/watch.scala
+++ b/tests/src/test/scala/sec/api/cluster/watch.scala
@@ -31,12 +31,15 @@ import fs2.Stream
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.scalacheck.Gen
+import org.specs2.specification.Retries
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 import sec.api.exceptions.ServerUnavailable
 import sec.arbitraries._
 
-class ClusterWatchSpec extends Specification with TestInstances with CatsEffect {
+class ClusterWatchSpec extends Specification with Retries with TestInstances with CatsEffect {
+
+  override def sleep: Duration = 500.millis
 
   import ClusterWatch.Cache
 


### PR DESCRIPTION
 - remove `ErrorM` and `ErrorA` type
   aliases.

 - make `ServerUnavailable` result in grpc
   `convertToEs` more detailed wrt. exception
   cause.

 - use specs2 `Retries` for tests that usually
   are flaky.

 - use esdb 21.6.0 for ci.