### PR TITLE
ci: use jdk17 for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  JABBA_INDEX: 'https://github.com/typelevel/jdk-index/raw/main/index.json'
 
 jobs:
   build:
@@ -24,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.0.2, 2.13.6]
-        java: [adopt@1.11]
+        java: [adoptium@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -122,7 +123,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.6]
-        java: [adopt@1.11]
+        java: [adoptium@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)

--- a/build.sbt
+++ b/build.sbt
@@ -194,7 +194,8 @@ val docsOnMain                      = "github.ref == 'refs/heads/main'"
 
 inThisBuild(
   List(
-    githubWorkflowJavaVersions := Seq("adopt@1.11"),
+    githubWorkflowEnv += ("JABBA_INDEX" -> "https://github.com/typelevel/jdk-index/raw/main/index.json"),
+    githubWorkflowJavaVersions := Seq("adoptium@17"),
     githubWorkflowTargetTags += "v*",
     githubWorkflowTargetBranches := Seq("main"),
     githubWorkflowBuildPreamble += WorkflowStep.Run(


### PR DESCRIPTION
- javac targets `"-target", "8", "-source", "8"` and scalac to targets java8, so this does not leave jdk8 out in the cold.