### PR TITLE
core: add `ULong` type to account for uint64 from esdb

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,11 @@
-//https://github.com/scalameta/scalafmt/releases
 version = "3.1.2"
+
+runner.dialect = scala213
+fileOverride {
+  "glob:**/scala-3/**" {
+    runner.dialect = scala3
+  }
+}
 
 maxColumn = 120
 
@@ -63,9 +69,3 @@ project {
   ]
 
 }
-
-fileOverride {
-   "glob:**/scala-3/**" {
-     runner.dialect = scala3
-   }
- }

--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -19,8 +19,6 @@ package api
 
 import scala.util.control.NoStackTrace
 
-import cats.syntax.all._
-
 object exceptions {
 
   sealed abstract class EsException private[sec] (
@@ -85,10 +83,10 @@ object exceptions {
     def adaptOrFallback(e: WrongExpectedVersion, sid: StreamId, expected: StreamState): Throwable = {
 
       def mkException(actual: StreamState) = WrongExpectedState(sid, expected, actual)
-      def noStream                         = mkException(StreamState.NoStream).some
-      def mkExact(a: Long)                 = StreamPosition.Exact(a).toOption.map(mkException)
+      def noStream                         = mkException(StreamState.NoStream)
+      def mkExact(a: Long)                 = mkException(StreamPosition(a))
 
-      e.actual.fold(noStream)(mkExact).getOrElse(e)
+      e.actual.fold(noStream)(mkExact)
     }
 
     implicit final class WrongExpectedVersionOps(val e: WrongExpectedVersion) extends AnyVal {

--- a/core/src/main/scala/sec/metadata.scala
+++ b/core/src/main/scala/sec/metadata.scala
@@ -216,7 +216,7 @@ private[sec] object MetaState {
         Codec.from(cfd.emap(CacheControl(_).leftMap(_.msg)), cfd.contramap(_.value))
 
       implicit val codecForStreamPositionExact: Codec[StreamPosition.Exact] =
-        Codec.from(dl.map(StreamPosition.exact), el.contramap(_.value))
+        Codec.from(dl.map(StreamPosition(_)), el.contramap(_.value.toLong))
 
       //
 
@@ -262,7 +262,7 @@ private[sec] object MetaState {
        |  max-age         = ${ms.maxAge.map(MaxAge.render).getOrElse("n/a")}
        |  max-count       = ${ms.maxCount.map(MaxCount.render).getOrElse("n/a")}
        |  cache-control   = ${ms.cacheControl.map(CacheControl.render).getOrElse("n/a")}
-       |  truncate-before = ${ms.truncateBefore.map(e => s"${e.value}L").getOrElse("n/a")}
+       |  truncate-before = ${ms.truncateBefore.map(e => s"${e.value.render}").getOrElse("n/a")}
        |  access-list     = ${ms.acl.map(StreamAcl.render).getOrElse("n/a")}
        |""".stripMargin
   }

--- a/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/metastreams.scala
@@ -90,6 +90,6 @@ final class MetaStreamsOps[F[_]: MonadThrow](val ms: MetaStreams[F]) {
     *   [[InvalidInput]] exception is raised for invalid input value.
     */
   def setTruncateBefore(id: Id, expectedState: StreamState, truncateBefore: Long): F[WriteResult] =
-    StreamPosition(truncateBefore).liftTo[F] >>= (ms.setTruncateBefore(id, expectedState, _))
+    ms.setTruncateBefore(id, expectedState, StreamPosition(truncateBefore))
 
 }

--- a/fs2/src/main/scala-3/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/metastreams.scala
@@ -85,7 +85,7 @@ trait MetaStreamsSyntax {
       *   An [[InvalidInput]] exception is raised for invalid input value.
       */
     def setTruncateBefore(id: Id, expectedState: StreamState, truncateBefore: Long): F[WriteResult] =
-      StreamPosition(truncateBefore).liftTo[F] >>= (ms.setTruncateBefore(id, expectedState, _))
+      ms.setTruncateBefore(id, expectedState, StreamPosition(truncateBefore))
 
   }
 

--- a/tests/src/main/scala/sec/arbitraries.scala
+++ b/tests/src/main/scala/sec/arbitraries.scala
@@ -56,9 +56,11 @@ object arbitraries {
 // StreamPosition, LogPosition, PositionInfo.Global & StreamState
 //======================================================================================================================
 
-  implicit val arbStreamPositionExact: Arbitrary[StreamPosition.Exact] = Arbitrary[StreamPosition.Exact](
-    Gen.chooseNum(0L, Long.MaxValue).map(StreamPosition.Exact(_).leftMap(require(false, _)).toOption.get)
-  )
+  implicit val ulong: Arbitrary[ULong] =
+    Arbitrary(arbitrary[Long].map(new ULong(_)))
+
+  implicit val arbStreamPositionExact: Arbitrary[StreamPosition.Exact] =
+    Arbitrary[StreamPosition.Exact](arbitrary(ulong).map(StreamPosition.Exact(_)))
 
   implicit val arbStreamPosition: Arbitrary[StreamPosition] =
     Arbitrary[StreamPosition](Gen.oneOf(List(StreamPosition.End, sampleOf[StreamPosition.Exact])))
@@ -275,7 +277,7 @@ object arbitraries {
       val zdt  = sampleOf[ZonedDateTime]
 
       data.zipWithIndex.map { case (ed, i) =>
-        val position = StreamPosition.exact(i.toLong)
+        val position = StreamPosition(i.toLong)
         val created  = zdt.plusSeconds(i.toLong)
         sec.EventRecord[PositionInfo.Local](sid, position, ed, created)
       }

--- a/tests/src/sit/scala/sec/api/metastreams.scala
+++ b/tests/src/sit/scala/sec/api/metastreams.scala
@@ -33,7 +33,7 @@ class MetaStreamsSuite extends SnSpec {
   "MetaStreams" should {
 
     import StreamState.NoStream
-    import StreamPosition.{exact, Start}
+    import StreamPosition.Start
 
     val mkStreamId: String => StreamId.Id =
       usecase => genStreamId(s"meta_streams_${genIdentifier}_$usecase")
@@ -66,13 +66,13 @@ class MetaStreamsSuite extends SnSpec {
       val meta1 = StreamMetadata.empty
         .withMaxCount(MaxCount(17).unsafe)
         .withMaxAge(MaxAge(1.day).unsafe)
-        .withTruncateBefore(exact(10))
+        .withTruncateBefore(StreamPosition(10))
         .withCacheControl(CacheControl(3.days).unsafe)
 
       val meta2 = StreamMetadata.empty
         .withMaxCount(MaxCount(37).unsafe)
         .withMaxAge(MaxAge(12.hours).unsafe)
-        .withTruncateBefore(exact(24))
+        .withTruncateBefore(StreamPosition(24))
         .withCacheControl(CacheControl(36.hours).unsafe)
 
       "using expected stream state no stream for first write and exact for second write" >> {
@@ -86,7 +86,7 @@ class MetaStreamsSuite extends SnSpec {
           mr2 <- metaStreams.getMetadata(sid)
         } yield {
           wr1.streamPosition shouldEqual Start
-          wr2.streamPosition shouldEqual exact(1L)
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           mr1 should beSome(Result(wr1.streamPosition, meta1))
           mr2 should beSome(Result(wr2.streamPosition, meta2))
         }
@@ -103,7 +103,7 @@ class MetaStreamsSuite extends SnSpec {
           mr2 <- metaStreams.getMetadata(sid)
         } yield {
           mr1 should beSome(Result(Start, meta1))
-          mr2 should beSome(Result(exact(1L), meta2))
+          mr2 should beSome(Result(StreamPosition(1L), meta2))
         }
 
       }
@@ -113,8 +113,8 @@ class MetaStreamsSuite extends SnSpec {
 
       val sid = mkStreamId("set_metadata_with_wrong_expected_revision_raises")
 
-      metaStreams.setMetadata(sid, exact(2), StreamMetadata.empty).attempt.map {
-        _ should beLeft(WrongExpectedState(sid.metaId, exact(2), StreamState.NoStream))
+      metaStreams.setMetadata(sid, StreamPosition(2), StreamMetadata.empty).attempt.map {
+        _ should beLeft(WrongExpectedState(sid.metaId, StreamPosition(2), StreamState.NoStream))
       }
     }
 
@@ -133,7 +133,7 @@ class MetaStreamsSuite extends SnSpec {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start
           ma2 should beSome(Result(Start, Some(MaxAge(1.day).unsafe)))
-          wr2.streamPosition shouldEqual exact(1L)
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           ma3 should beSome(Result(wr2.streamPosition, None))
         }
       }
@@ -151,7 +151,7 @@ class MetaStreamsSuite extends SnSpec {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start
           ma2 should beSome(Result(Start, Some(MaxCount(10).unsafe)))
-          wr2.streamPosition shouldEqual exact(1L)
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           ma3 should beSome(Result(wr2.streamPosition, None))
         }
       }
@@ -169,7 +169,7 @@ class MetaStreamsSuite extends SnSpec {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start
           ma2 should beSome(Result(Start, Some(CacheControl(20.days).unsafe)))
-          wr2.streamPosition shouldEqual exact(1L)
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           ma3 should beSome(Result(wr2.streamPosition, None))
         }
       }
@@ -188,7 +188,7 @@ class MetaStreamsSuite extends SnSpec {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start
           ma2 should beSome(Result(Start, Some(rr)))
-          wr2.streamPosition shouldEqual exact(1L)
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           ma3 should beSome(Result(wr2.streamPosition, None))
         }
       }
@@ -205,8 +205,8 @@ class MetaStreamsSuite extends SnSpec {
         } yield {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start
-          ma2 should beSome(Result(Start, Some(exact(100L))))
-          wr2.streamPosition shouldEqual exact(1L)
+          ma2 should beSome(Result(Start, Some(StreamPosition(100L))))
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           ma3 should beSome(Result(wr2.streamPosition, None))
         }
       }
@@ -225,7 +225,7 @@ class MetaStreamsSuite extends SnSpec {
           ma1 should beNone
           wr1.streamPosition shouldEqual Start
           ma2 should beSome(Result(Start, Some(foo)))
-          wr2.streamPosition shouldEqual exact(1L)
+          wr2.streamPosition shouldEqual StreamPosition(1L)
           ma3 should beSome(Result(wr2.streamPosition, None))
         }
 

--- a/tests/src/test/scala/sec/event.scala
+++ b/tests/src/test/scala/sec/event.scala
@@ -36,14 +36,14 @@ class EventSpec extends Specification {
 
   val er: EventRecord[PositionInfo.Global] = sec.EventRecord[PositionInfo.Global](
     StreamId("abc-1234").unsafe,
-    PositionInfo.Global(StreamPosition.exact(5L), LogPosition.exact(42L, 42L)),
+    PositionInfo.Global(StreamPosition(5L), LogPosition.exact(42L, 42L)),
     EventData("et", sampleOf[ju.UUID], bv("abc"), ContentType.Binary).unsafe,
     sampleOf[ZonedDateTime]
   )
 
   val link: EventRecord[PositionInfo.Global] = sec.EventRecord[PositionInfo.Global](
     StreamId.system("ce-abc").unsafe,
-    PositionInfo.Global(StreamPosition.exact(10L), LogPosition.exact(1337L, 1337L)),
+    PositionInfo.Global(StreamPosition(10L), LogPosition.exact(1337L, 1337L)),
     EventData(EventType.LinkTo, sampleOf[ju.UUID], bv("5@abc-1234"), ContentType.Binary),
     sampleOf[ZonedDateTime]
   )

--- a/tests/src/test/scala/sec/metadata.scala
+++ b/tests/src/test/scala/sec/metadata.scala
@@ -52,7 +52,7 @@ class StreamMetadataSpec extends Specification {
       maxAge         = MaxAge(1000.seconds).unsafe.some,
       maxCount       = None,
       cacheControl   = CacheControl(12.hours).unsafe.some,
-      truncateBefore = StreamPosition.exact(1000L).some,
+      truncateBefore = StreamPosition(1000L).some,
       acl            = StreamAcl.empty.copy(readRoles = Set("a", "b")).some
     )
 
@@ -92,7 +92,7 @@ class MetaStateSpec extends Specification {
     val expectedMap = Map(
       "$maxAge"       -> ms.maxAge.map(_.value.toSeconds).asJson,
       "$maxCount"     -> ms.maxCount.map(_.value).asJson,
-      "$tb"           -> ms.truncateBefore.map(_.value).asJson,
+      "$tb"           -> ms.truncateBefore.map(_.value.toLong).asJson,
       "$acl"          -> ms.acl.asJson,
       "$cacheControl" -> ms.cacheControl.map(_.value.toSeconds).asJson
     )
@@ -121,14 +121,14 @@ class MetaStateSpec extends Specification {
       maxAge         = None,
       maxCount       = MaxCount(50).toOption,
       cacheControl   = CacheControl(12.hours).toOption,
-      truncateBefore = StreamPosition.exact(1000L).some,
+      truncateBefore = StreamPosition(1000L).some,
       acl            = StreamAcl.empty.copy(readRoles = Set("a", "b")).some
     ).render shouldEqual s"""
        |MetaState:
        |  max-age         = n/a
        |  max-count       = 50 events
        |  cache-control   = 12 hours
-       |  truncate-before = 1000L
+       |  truncate-before = 1000
        |  access-list     = read: [a, b], write: [], delete: [], meta-read: [], meta-write: []
        |""".stripMargin
 

--- a/tests/src/test/scala/sec/position.scala
+++ b/tests/src/test/scala/sec/position.scala
@@ -16,13 +16,16 @@
 
 package sec
 
+import java.lang.{Long => JLong}
+import cats.syntax.all._
 import cats.kernel.laws.discipline._
 import org.scalacheck._
 import org.specs2.mutable.Specification
+import org.specs2.ScalaCheck
 import org.typelevel.discipline.specs2.mutable.Discipline
 import sec.arbitraries._
 
-class VersionSpec extends Specification with Discipline {
+class VersionSpec extends Specification with Discipline with ScalaCheck {
 
   "StreamState" >> {
 
@@ -34,7 +37,7 @@ class VersionSpec extends Specification with Discipline {
       test(StreamState.NoStream, "NoStream")
       test(StreamState.Any, "Any")
       test(StreamState.StreamExists, "StreamExists")
-      test(StreamPosition.Start, "Exact(0L)")
+      test(StreamPosition.Start, "Exact(0)")
     }
 
     "Eq" >> {
@@ -46,13 +49,13 @@ class VersionSpec extends Specification with Discipline {
   "StreamPosition" >> {
 
     "apply" >> {
-      StreamPosition(0L) should beRight(StreamPosition.exact(0L))
-      StreamPosition(1L) should beRight(StreamPosition.exact(1L))
-      StreamPosition(-1L) should beLeft(InvalidInput("value must be >= 0, but is -1"))
+      StreamPosition(0L) shouldEqual StreamPosition.Exact(ULong(0L))
+      StreamPosition(1L) shouldEqual StreamPosition.Exact(ULong(1L))
+      StreamPosition(-1L) shouldEqual StreamPosition.Exact(ULong.MaxValue)
     }
 
     "render" >> {
-      (StreamPosition.Start: StreamPosition).render shouldEqual "0L"
+      (StreamPosition.Start: StreamPosition).render shouldEqual "0"
       (StreamPosition.End: StreamPosition).render shouldEqual "end"
     }
 
@@ -68,13 +71,12 @@ class VersionSpec extends Specification with Discipline {
       LogPosition(0L, 0L) should beRight(LogPosition.exact(0L, 0L))
       LogPosition(1L, 0L) should beRight(LogPosition.exact(1L, 0L))
       LogPosition(1L, 1L) should beRight(LogPosition.exact(1L, 1L))
-      LogPosition(-1L, 0L) should beLeft(InvalidInput("commit must be >= 0, but is -1"))
-      LogPosition(0L, -1L) should beLeft(InvalidInput("prepare must be >= 0, but is -1"))
+      LogPosition(-1L, -1L) should beRight(LogPosition.Exact.create(ULong.MaxValue, ULong.MaxValue))
       LogPosition(0L, 1L) should beLeft(InvalidInput("commit must be >= prepare, but 0 < 1"))
     }
 
     "render" >> {
-      (LogPosition.Start: LogPosition).render shouldEqual "(c = 0L, p = 0L)"
+      (LogPosition.Start: LogPosition).render shouldEqual "(c = 0, p = 0)"
       (LogPosition.End: LogPosition).render shouldEqual "end"
     }
 
@@ -88,21 +90,77 @@ class VersionSpec extends Specification with Discipline {
 
     "renderPosition" >> {
 
-      val stream = StreamPosition.exact(1L)
+      val stream = StreamPosition(1L)
       val all    = PositionInfo.Global(stream, LogPosition.exact(2L, 3L))
 
-      (stream: PositionInfo).renderPosition shouldEqual "stream: 1L"
-      (all: PositionInfo).renderPosition shouldEqual "log: (c = 2L, p = 3L), stream: 1L"
+      (stream: PositionInfo).renderPosition shouldEqual "stream: 1"
+      (all: PositionInfo).renderPosition shouldEqual "log: (c = 2, p = 3), stream: 1"
     }
 
     "streamPosition" >> {
 
-      val stream = StreamPosition.exact(1L)
+      val stream = StreamPosition(1L)
       val all    = PositionInfo.Global(stream, LogPosition.exact(2L, 3L))
 
-      (stream: PositionInfo).streamPosition shouldEqual StreamPosition.exact(1L)
-      (all: PositionInfo).streamPosition shouldEqual StreamPosition.exact(1L)
+      (stream: PositionInfo).streamPosition shouldEqual StreamPosition(1L)
+      (all: PositionInfo).streamPosition shouldEqual StreamPosition(1L)
 
+    }
+
+  }
+
+  "ULong" >> {
+
+    "n >= 0" >> {
+      prop((n: ULong) => n >= ULong.MinValue == true)
+    }
+
+    "a < b" >> {
+      prop((a: ULong, b: ULong) => a < b == a.toBigInt < b.toBigInt)
+    }
+
+    "a <= b" >> {
+      prop((a: ULong, b: ULong) => a <= b == a.toBigInt <= b.toBigInt)
+    }
+
+    "a > b" >> {
+      prop((a: ULong, b: ULong) => a > b == a.toBigInt > b.toBigInt)
+    }
+
+    "a >= b" >> {
+      prop((a: ULong, b: ULong) => a >= b == a.toBigInt >= b.toBigInt)
+    }
+
+    "MaxValue / MinValue" >> {
+      ULong.MaxValue shouldEqual ULong(-1)
+      ULong.MinValue shouldEqual ULong(0)
+    }
+
+    "toLong" >> {
+      ULong.MaxValue.toLong shouldEqual -1
+      ULong.MinValue.toLong shouldEqual 0
+    }
+
+    "toBigInt" >> {
+      ULong.MaxValue.toBigInt shouldEqual BigInt("18446744073709551615")
+      ULong.MinValue.toBigInt shouldEqual BigInt(0)
+    }
+
+    "n.toBigInt == BigInt(Long.toUnsignedString(n.toLong))" >> {
+      prop((n: ULong) => n.toBigInt == BigInt(JLong.toUnsignedString(n.toLong)))
+    }
+
+    "n.render" >> {
+      prop((n: ULong) => n.render == n.toBigInt.toString)
+    }
+
+    "n.toString = n.toBigInt.toString" >> {
+      prop((n: ULong) => n.toString == n.toBigInt.toString)
+    }
+
+    "Order" >> {
+      implicit val cogen: Cogen[ULong] = Cogen[BigInt].contramap[ULong](_.toBigInt)
+      checkAll("ULong", OrderTests[ULong].order)
     }
 
   }


### PR DESCRIPTION
 - add simple `ULong` type that utilizes functionality
   from `java.lang.Long` in order to be able to handle
   `uint64` coming from ESDB.

 - adjust code accordingly.