### PR TITLE
fs2/api: guard against esdb doing stuff it should not

### DIFF
--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -431,7 +431,7 @@ object Streams {
   private[sec] def subscriptionAllPipe[F[_]: MonadThrow](
     log: Logger[F]
   ): Pipe[F, ReadResp, AllEvent] =
-    _.through(subConfirmationPipe(log)).through(readAllEventPipe)
+    _.filterNot(_.content.isCheckpoint).through(subConfirmationPipe(log)).through(readAllEventPipe)
 
   private[sec] def subscriptionStreamPipe[F[_]: MonadThrow](
     log: Logger[F]


### PR DESCRIPTION
 - filter checkpoints when subscribing to all without
   filter options, hence not doing server side filtering.
   This happens in 21.10.x and is a change from esdb versions
   20.10.x/21.6.x.