### PR TITLE
all: moving to esdb 21.10.0

### DIFF
--- a/.docker/cluster.ci.yml
+++ b/.docker/cluster.ci.yml
@@ -6,7 +6,7 @@ x-common-variables: &common-variables
 services:
 
   es1:
-    image: eventstore/eventstore:21.6.0-bionic
+    image: eventstore/eventstore:21.10.0-bionic
     env_file:
       - ./shared.env
     environment:
@@ -24,7 +24,7 @@ services:
       - cert-gen
 
   es2:
-    image: eventstore/eventstore:21.6.0-bionic
+    image: eventstore/eventstore:21.10.0-bionic
     env_file:
       - ./shared.env
     environment:
@@ -42,7 +42,7 @@ services:
       - cert-gen
 
   es3:
-    image: eventstore/eventstore:21.6.0-bionic
+    image: eventstore/eventstore:21.10.0-bionic
     env_file:
       - ./shared.env
     environment:

--- a/.docker/single-node.ci.yml
+++ b/.docker/single-node.ci.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   es:
-    image: eventstore/eventstore:21.6.0-bionic
+    image: eventstore/eventstore:21.10.0-bionic
     env_file:
       - ./shared.env
     environment:

--- a/core/src/main/scala/sec/api/streams.scala
+++ b/core/src/main/scala/sec/api/streams.scala
@@ -17,12 +17,29 @@
 package sec
 package api
 
+import cats.Order
+import cats.syntax.all._
+
 /** Checkpoint result used with server-side filtering in EventStoreDB. Contains the [[LogPosition.Exact]] when the
   * checkpoint was made.
   */
 final case class Checkpoint(
   logPosition: LogPosition.Exact
 )
+
+object Checkpoint {
+
+  val endOfStream: Checkpoint =
+    Checkpoint(LogPosition.Exact.MaxValue)
+
+  implicit final class CheckpointOps(val c: Checkpoint) extends AnyVal {
+    def isEndOfStream: Boolean = c === endOfStream
+  }
+
+  implicit val orderForCheckpoint: Order[Checkpoint] =
+    Order.by(_.logPosition)
+
+}
 
 /** The current last [[StreamPosition.Exact]] of the stream appended to and its corresponding [[LogPosition.Exact]] in
   * the transaction log.

--- a/core/src/main/scala/sec/position.scala
+++ b/core/src/main/scala/sec/position.scala
@@ -129,6 +129,8 @@ object LogPosition {
   sealed abstract case class Exact(commit: ULong, prepare: ULong) extends LogPosition
   object Exact {
 
+    val MaxValue: Exact = create(ULong.MaxValue, ULong.MaxValue)
+
     private[sec] def create(commit: ULong, prepare: ULong): Exact =
       new Exact(commit, prepare) {}
 

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -441,7 +441,12 @@ object Streams {
   private[sec] def subAllFilteredPipe[F[_]: MonadThrow](
     log: Logger[F]
   ): Pipe[F, ReadResp, Either[Checkpoint, AllEvent]] =
-    _.through(subConfirmationPipe(log)).through(_.evalMap(mkCheckpointOrEvent[F]).unNone)
+    // Defensive filtering to guard against ESDB emitting checkpoints 
+    // with `LogPosition.Exact.MaxValue`, i.e. end of stream.
+    _.through(subConfirmationPipe(log)).through(_.evalMap(mkCheckpointOrEvent[F]).unNone).collect {
+      case r @ Right(_)                               => r
+      case l @ Left(v) if v != Checkpoint.endOfStream => l
+    }
 
   private[sec] def withRetry[F[_]: Temporal, T: Order, O](
     from: T,


### PR DESCRIPTION
 - add fixes for changed behaviour in esdb 21.10.x
   and adjusments to tests along the way. Tests with
   respect to changes in soft deletes on *server*
   do not differentiate between various versions of
   esdb. Version info could be passed to tests in order
   to know which tests to exclude/include in scenarios
   like this. It might be an idea to use test containers
   to test a reasonable matrix of esdb versions.

 - All tests pass with 20.10.4 and 21.6.0 when
   reverting soft delete test changes, manually and
   locally, like a boss.