### PR TITLE
protobuf: sync with upstream wrt. first/last positions

### DIFF
--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -18,7 +18,7 @@ package sec
 package api
 package mapping
 
-import cats.{ApplicativeThrow, MonadThrow}
+import cats.{Applicative, ApplicativeThrow, MonadThrow}
 import cats.data.{NonEmptyList, OptionT}
 import cats.syntax.all._
 import com.eventstore.dbclient.proto.shared._
@@ -152,6 +152,7 @@ private[sec] object streams {
         .withResolveLinks(resolveLinkTos)
         .withNoFilter(empty)
         .withUuidOption(uuidOption)
+        .withControlOption(ReadReq.Options.ControlOption(1))
 
       ReadReq().withOptions(options)
     }
@@ -171,6 +172,7 @@ private[sec] object streams {
         .withResolveLinks(resolveLinkTos)
         .withNoFilter(empty)
         .withUuidOption(uuidOption)
+        .withControlOption(ReadReq.Options.ControlOption(1))
 
       ReadReq().withOptions(options)
     }
@@ -231,7 +233,7 @@ private[sec] object streams {
     def mkLogPosition[F[_]: ApplicativeThrow](e: ReadResp.ReadEvent.RecordedEvent): F[LogPosition.Exact] =
       LogPosition(e.commitPosition, e.preparePosition).liftTo[F]
 
-    def mkStreamPosition[F[_]: ApplicativeThrow](e: ReadResp.ReadEvent.RecordedEvent): F[StreamPosition.Exact] =
+    def mkStreamPosition[F[_]: Applicative](e: ReadResp.ReadEvent.RecordedEvent): F[StreamPosition.Exact] =
       StreamPosition(e.streamRevision).pure[F]
 
     def mkCheckpoint[F[_]: ApplicativeThrow](c: ReadResp.Checkpoint): F[Checkpoint] =

--- a/protobuf/gossip.proto
+++ b/protobuf/gossip.proto
@@ -5,7 +5,7 @@ option java_package = "com.eventstore.dbclient.proto.gossip";
 import "shared.proto";
 
 service Gossip {
-	rpc Read (event_store.client.shared.Empty) returns (ClusterInfo);
+	rpc Read (event_store.client.Empty) returns (ClusterInfo);
 }
 
 message ClusterInfo {
@@ -36,7 +36,7 @@ message MemberInfo {
 		ReadOnlyReplica = 14;
 		ResigningLeader = 15;
 	}
-	event_store.client.shared.UUID instance_id = 1;
+	event_store.client.UUID instance_id = 1;
 	int64 time_stamp = 2;
 	VNodeState state = 3;
 	bool is_alive = 4;

--- a/protobuf/shared.proto
+++ b/protobuf/shared.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package event_store.client.shared;
+package event_store.client;
 option java_package = "com.eventstore.dbclient.proto.shared";
 
 message UUID {
@@ -19,4 +19,9 @@ message Empty {
 message StreamIdentifier {
 	reserved 1 to 2;
 	bytes streamName = 3;
+}
+
+message AllStreamPosition {
+	uint64 commit_position = 1;
+	uint64 prepare_position = 2;
 }

--- a/protobuf/streams.proto
+++ b/protobuf/streams.proto
@@ -27,27 +27,28 @@ message ReadReq {
 		}
 		oneof filter_option {
 			FilterOptions filter = 7;
-			event_store.client.shared.Empty no_filter = 8;
+			event_store.client.Empty no_filter = 8;
 		}
 		UUIDOption uuid_option = 9;
+		ControlOption control_option = 10;
 
 		enum ReadDirection {
 			Forwards = 0;
 			Backwards = 1;
 		}
 		message StreamOptions {
-			event_store.client.shared.StreamIdentifier stream_identifier = 1;
+			event_store.client.StreamIdentifier stream_identifier = 1;
 			oneof revision_option {
 				uint64 revision = 2;
-				event_store.client.shared.Empty start = 3;
-				event_store.client.shared.Empty end = 4;
+				event_store.client.Empty start = 3;
+				event_store.client.Empty end = 4;
 			}
 		}
 		message AllOptions {
 			oneof all_option {
 				Position position = 1;
-				event_store.client.shared.Empty start = 2;
-				event_store.client.shared.Empty end = 3;
+				event_store.client.Empty start = 2;
+				event_store.client.Empty end = 3;
 			}
 		}
 		message SubscriptionOptions {
@@ -63,7 +64,7 @@ message ReadReq {
 			}
 			oneof window {
 				uint32 max = 3;
-				event_store.client.shared.Empty count = 4;
+				event_store.client.Empty count = 4;
 			}
 			uint32 checkpointIntervalMultiplier = 5;
 
@@ -74,9 +75,12 @@ message ReadReq {
 		}
 		message UUIDOption {
 			oneof content {
-				event_store.client.shared.Empty structured = 1;
-				event_store.client.shared.Empty string = 2;
+				event_store.client.Empty structured = 1;
+				event_store.client.Empty string = 2;
 			}
+		}
+		message ControlOption {
+			uint32 compatibility = 1;
 		}
 	}
 }
@@ -87,6 +91,9 @@ message ReadResp {
 		SubscriptionConfirmation confirmation = 2;
 		Checkpoint checkpoint = 3;
 		StreamNotFound stream_not_found = 4;
+		uint64 first_stream_position = 5;
+		uint64 last_stream_position = 6;
+		AllStreamPosition last_all_stream_position = 7;
 	}
 
 	message ReadEvent {
@@ -94,12 +101,12 @@ message ReadResp {
 		RecordedEvent link = 2;
 		oneof position {
 			uint64 commit_position = 3;
-			event_store.client.shared.Empty no_position = 4;
+			event_store.client.Empty no_position = 4;
 		}
 
 		message RecordedEvent {
-			event_store.client.shared.UUID id = 1;
-			event_store.client.shared.StreamIdentifier stream_identifier = 2;
+			event_store.client.UUID id = 1;
+			event_store.client.StreamIdentifier stream_identifier = 2;
 			uint64 stream_revision = 3;
 			uint64 prepare_position = 4;
 			uint64 commit_position = 5;
@@ -116,7 +123,7 @@ message ReadResp {
 		uint64 prepare_position = 2;
 	}
 	message StreamNotFound {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		event_store.client.StreamIdentifier stream_identifier = 1;
 	}
 }
 
@@ -127,16 +134,16 @@ message AppendReq {
 	}
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		event_store.client.StreamIdentifier stream_identifier = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			event_store.client.shared.Empty no_stream = 3;
-			event_store.client.shared.Empty any = 4;
-			event_store.client.shared.Empty stream_exists = 5;
+			event_store.client.Empty no_stream = 3;
+			event_store.client.Empty any = 4;
+			event_store.client.Empty stream_exists = 5;
 		}
 	}
 	message ProposedMessage {
-		event_store.client.shared.UUID id = 1;
+		event_store.client.UUID id = 1;
 		map<string, string> metadata = 2;
 		bytes custom_metadata = 3;
 		bytes data = 4;
@@ -157,33 +164,33 @@ message AppendResp {
 	message Success {
 		oneof current_revision_option {
 			uint64 current_revision = 1;
-			event_store.client.shared.Empty no_stream = 2;
+			event_store.client.Empty no_stream = 2;
 		}
 		oneof position_option {
 			Position position = 3;
-			event_store.client.shared.Empty no_position = 4;
+			event_store.client.Empty no_position = 4;
 		}
 	}
 
 	message WrongExpectedVersion {
 		oneof current_revision_option_20_6_0 {
 			uint64 current_revision_20_6_0 = 1;
-			event_store.client.shared.Empty no_stream_20_6_0 = 2;
+			event_store.client.Empty no_stream_20_6_0 = 2;
 		}
 		oneof expected_revision_option_20_6_0 {
 			uint64 expected_revision_20_6_0 = 3;
-			event_store.client.shared.Empty any_20_6_0 = 4;
-			event_store.client.shared.Empty stream_exists_20_6_0 = 5;
+			event_store.client.Empty any_20_6_0 = 4;
+			event_store.client.Empty stream_exists_20_6_0 = 5;
 		}
 		oneof current_revision_option {
 			uint64 current_revision = 6;
-			event_store.client.shared.Empty current_no_stream = 7;
+			event_store.client.Empty current_no_stream = 7;
 		}
 		oneof expected_revision_option {
 			uint64 expected_revision = 8;
-			event_store.client.shared.Empty expected_any = 9;
-			event_store.client.shared.Empty expected_stream_exists = 10;
-			event_store.client.shared.Empty expected_no_stream = 11;
+			event_store.client.Empty expected_any = 9;
+			event_store.client.Empty expected_stream_exists = 10;
+			event_store.client.Empty expected_no_stream = 11;
 		}
 
 	}
@@ -193,12 +200,12 @@ message DeleteReq {
 	Options options = 1;
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		event_store.client.StreamIdentifier stream_identifier = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			event_store.client.shared.Empty no_stream = 3;
-			event_store.client.shared.Empty any = 4;
-			event_store.client.shared.Empty stream_exists = 5;
+			event_store.client.Empty no_stream = 3;
+			event_store.client.Empty any = 4;
+			event_store.client.Empty stream_exists = 5;
 		}
 	}
 }
@@ -206,7 +213,7 @@ message DeleteReq {
 message DeleteResp {
 	oneof position_option {
 		Position position = 1;
-		event_store.client.shared.Empty no_position = 2;
+		event_store.client.Empty no_position = 2;
 	}
 
 	message Position {
@@ -219,12 +226,12 @@ message TombstoneReq {
 	Options options = 1;
 
 	message Options {
-		event_store.client.shared.StreamIdentifier stream_identifier = 1;
+		event_store.client.StreamIdentifier stream_identifier = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			event_store.client.shared.Empty no_stream = 3;
-			event_store.client.shared.Empty any = 4;
-			event_store.client.shared.Empty stream_exists = 5;
+			event_store.client.Empty no_stream = 3;
+			event_store.client.Empty any = 4;
+			event_store.client.Empty stream_exists = 5;
 		}
 	}
 }
@@ -232,7 +239,7 @@ message TombstoneReq {
 message TombstoneResp {
 	oneof position_option {
 		Position position = 1;
-		event_store.client.shared.Empty no_position = 2;
+		event_store.client.Empty no_position = 2;
 	}
 
 	message Position {

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -214,6 +214,7 @@ class StreamsMappingSpec extends mutable.Specification {
               .withResolveLinks(rlt)
               .withNoFilter(empty)
               .withUuidOption(uuidOption)
+              .withControlOption(s.ReadReq.Options.ControlOption(compatibility = 1))
           )
 
       for {
@@ -239,6 +240,7 @@ class StreamsMappingSpec extends mutable.Specification {
               .withResolveLinks(rlt)
               .withNoFilter(empty)
               .withUuidOption(uuidOption)
+              .withControlOption(s.ReadReq.Options.ControlOption(compatibility = 1))
           )
 
       for {


### PR DESCRIPTION
 - use `ControlOption` with compatibility set to 1 in
   `ReadReq` for `readStream` and `readAll` use cases.

 - filter out new position messages in read operations
   for normal high-level api.

 - This is followed up with a low-level api that exposes
   these messages in `readStream` and `readAll`.