### PR TITLE
core: add base64 certificate opt to withSecureMode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,7 @@ lazy val tests = project
     Test / headerSources ++= (SingleNodeITest / sources).value ++ (ClusterITest / sources).value,
     libraryDependencies :=
       compileM(
+        fs2Io,
         catsLaws,
         scalaCheck,
         munit,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,6 +29,7 @@ object Dependencies {
   val cats         = "org.typelevel"           %% "cats-core"         % versions.catsCore
   val catsEffect   = "org.typelevel"           %% "cats-effect"       % versions.catsEffect
   val fs2          = "co.fs2"                  %% "fs2-core"          % versions.fs2
+  val fs2Io        = "co.fs2"                  %% "fs2-io"            % versions.fs2
   val log4cats     = "org.typelevel"           %% "log4cats-core"     % versions.log4cats
   val log4catsNoop = "org.typelevel"           %% "log4cats-noop"     % versions.log4cats
   val unum         = "io.github.ahjohannessen" %% "unum"              % versions.unum

--- a/tests/src/sit/scala/sec/api/channel.scala
+++ b/tests/src/sit/scala/sec/api/channel.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Scala EventStoreDB Client
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import cats.syntax.all._
+import cats.effect.IO
+import fs2.text
+import fs2.io.file._
+import io.grpc.{ChannelCredentials, TlsChannelCredentials}
+import channel.mkCredentials
+import ConnectionMode._
+
+class ChannelSuite extends SecEffectSuite {
+
+  group("mkCredentials") {
+
+    test("ConnectionMode.Insecure yields none[ChannelCredentials]") {
+      assertIO(mkCredentials[IO](Insecure), none[ChannelCredentials])
+    }
+
+    test("ConnectionMode.Secure(file) yields some[TlsChannelCredentials]") {
+      assertIOBoolean(
+        mkCredentials[IO](Secure(SnSuite.cert)).map(_.exists(_.isInstanceOf[TlsChannelCredentials]))
+      )
+    }
+
+    test("ConnectionMode.Secure(base64) yields some[TlsChannelCredentials]") {
+      assertIOBoolean(
+        Files[IO]
+          .readAll(Path(SnSuite.cert.getPath))
+          .through(text.base64.encode)
+          .through(text.lines)
+          .compile
+          .foldMonoid
+          .flatMap(c64 => mkCredentials[IO](Secure(c64)).map(_.exists(_.isInstanceOf[TlsChannelCredentials])))
+      )
+    }
+
+  }
+
+}

--- a/tests/src/sit/scala/sec/api/snsuite.scala
+++ b/tests/src/sit/scala/sec/api/snsuite.scala
@@ -48,10 +48,11 @@ trait SnSuite extends ClientSuite {
 object SnSuite {
 
   final private val certsFolder = new File(sys.env.getOrElse("SEC_SIT_CERTS_PATH", BuildInfo.certsPath))
-  final private val cert        = new File(certsFolder, "ca/ca.crt")
-  final private val authority   = sys.env.getOrElse("SEC_SIT_AUTHORITY", "es.sec.local")
-  final private val address     = sys.env.getOrElse("SEC_SIT_HOST_ADDRESS", "127.0.0.1")
-  final private val port        = sys.env.get("SEC_SIT_HOST_PORT").flatMap(_.toIntOption).getOrElse(2113)
+  final val cert                = new File(certsFolder, "ca/ca.crt")
+
+  final private val authority = sys.env.getOrElse("SEC_SIT_AUTHORITY", "es.sec.local")
+  final private val address   = sys.env.getOrElse("SEC_SIT_HOST_ADDRESS", "127.0.0.1")
+  final private val port      = sys.env.get("SEC_SIT_HOST_PORT").flatMap(_.toIntOption).getOrElse(2113)
 
   //
 

--- a/tests/src/test/scala/sec/tsc/config.scala
+++ b/tests/src/test/scala/sec/tsc/config.scala
@@ -19,8 +19,9 @@ package tsc
 
 import java.io.File
 import scala.concurrent.duration._
-import com.typesafe.config._
 import cats.data.NonEmptySet
+import cats.syntax.all._
+import com.typesafe.config._
 import org.typelevel.log4cats.noop.NoOpLogger
 import sec.tsc.config._
 import sec.api._
@@ -251,6 +252,44 @@ class ConfigSuite extends SecSuite {
         .withOperationsRetryMaxAttempts(1000)
 
       assertEquals(mkOptions[ErrorOr](cfg), Right(expected))
+
+    }
+
+    test("config/certificate") {
+
+      val cfg1 = ConfigFactory.parseString(
+        """
+          | sec {
+          |   certificate-path = "path/to/certificate"
+          |   certificate-b64  = "cTaciKkQb2IAgPPfl1OdE3ErJtHyRXNbLAcI0ISciS4="
+          | }
+          |""".stripMargin
+      )
+
+      assertEquals(
+        mkOptions[ErrorOr](cfg1),
+        Options.default.withSecureMode(new File("path/to/certificate")).asRight
+      )
+
+      val cfg2 = ConfigFactory.parseString(
+        """sec.certificate-b64 = "cTaciKkQb2IAgPPfl1OdE3ErJtHyRXNbLAcI0ISciS4=""""
+      )
+
+      assertEquals(
+        mkOptions[ErrorOr](cfg2),
+        Options.default.withSecureMode("cTaciKkQb2IAgPPfl1OdE3ErJtHyRXNbLAcI0ISciS4=").asRight
+      )
+
+      val cfg3 = ConfigFactory.parseString(
+        """
+          | sec {
+          |   certificate-path = ""
+          |   certificate-b64 = ""
+          | }
+          |""".stripMargin
+      )
+
+      assertEquals(mkOptions[ErrorOr](cfg3), Options.default.withInsecureMode.asRight)
 
     }
 


### PR DESCRIPTION
 - make it possible to use a certificate that is base64 encoded as an alternative to file.

 - adjust tsc to account for base64 certificate string.