### PR TITLE
all: remove position info

### DIFF
--- a/core/src/main/scala/sec/api/streams.scala
+++ b/core/src/main/scala/sec/api/streams.scala
@@ -75,7 +75,7 @@ final private[sec] case class SubscriptionConfirmation(
   *
   * There are four variants:
   *
-  *   - [[StreamMessage.Event]] A regular [[StreamEvent]].
+  *   - [[StreamMessage.StreamEvent]] A regular [[Event]].
   *   - [[StreamMessage.FirstStreamPosition]] The first position of a stream.
   *   - [[StreamMessage.LastStreamPosition]] The last position of a stream.
   *   - [[StreamMessage.NotFound]] Representing a stream that was not found.
@@ -83,7 +83,7 @@ final private[sec] case class SubscriptionConfirmation(
 sealed trait StreamMessage
 object StreamMessage {
 
-  final case class Event(event: StreamEvent) extends StreamMessage
+  final case class StreamEvent(event: Event) extends StreamMessage
   final case class FirstStreamPosition(position: StreamPosition) extends StreamMessage
   final case class LastStreamPosition(position: StreamPosition) extends StreamMessage
   final case class NotFound(streamId: StreamId) extends StreamMessage
@@ -98,18 +98,18 @@ object StreamMessage {
   implicit final class StreamMessageOps(val sm: StreamMessage) extends AnyVal {
 
     def fold[A](
-      eFn: Event => A,
+      seFn: StreamEvent => A,
       fpFn: FirstStreamPosition => A,
       lpFn: LastStreamPosition => A,
       nfFn: NotFound => A
     ): A = sm match {
-      case x: Event               => eFn(x)
+      case x: StreamEvent         => seFn(x)
       case x: FirstStreamPosition => fpFn(x)
       case x: LastStreamPosition  => lpFn(x)
       case x: NotFound            => nfFn(x)
     }
 
-    def event: Option[Event]               = fold(_.some, _ => none, _ => none, _ => none)
+    def event: Option[StreamEvent]         = fold(_.some, _ => none, _ => none, _ => none)
     def first: Option[FirstStreamPosition] = fold(_ => none, _.some, _ => none, _ => none)
     def last: Option[LastStreamPosition]   = fold(_ => none, _ => none, _.some, _ => none)
     def notFound: Option[NotFound]         = fold(_ => none, _ => none, _ => none, _.some)
@@ -127,13 +127,13 @@ object StreamMessage {
   *
   * There are two variants:
   *
-  *   - [[AllMessage.Event]] A regular [[AllEvent]].
+  *   - [[AllMessage.AllEvent]] A regular [[Event]].
   *   - [[AllMessage.LastAllStreamPosition]] The last position in the global, [[sec.StreamId.All]], stream.
   */
 sealed trait AllMessage
 object AllMessage {
 
-  final case class Event(event: AllEvent) extends AllMessage
+  final case class AllEvent(event: Event) extends AllMessage
   final case class LastAllStreamPosition(position: LogPosition) extends AllMessage
 
   //
@@ -141,14 +141,14 @@ object AllMessage {
   implicit final class AllMessageOps(val am: AllMessage) extends AnyVal {
 
     def fold[A](
-      eFn: Event => A,
+      aeFn: AllEvent => A,
       lpFn: LastAllStreamPosition => A
     ): A = am match {
-      case x: Event                 => eFn(x)
+      case x: AllEvent              => aeFn(x)
       case x: LastAllStreamPosition => lpFn(x)
     }
 
-    def event: Option[Event]                = fold(_.some, _ => none)
+    def event: Option[AllEvent]             = fold(_.some, _ => none)
     def last: Option[LastAllStreamPosition] = fold(_ => none, _.some)
 
     def isEvent: Boolean = event.isDefined

--- a/core/src/main/scala/sec/package.scala
+++ b/core/src/main/scala/sec/package.scala
@@ -16,11 +16,6 @@
 
 package object sec {
 
-  type AllEvent    = sec.Event[PositionInfo.Global]
-  type StreamEvent = sec.Event[PositionInfo.Local]
-
-  // /
-
   private[sec] type Attempt[T] = Either[String, T]
   private[sec] type ErrorOr[T] = Either[Throwable, T]
 

--- a/core/src/main/scala/sec/position.scala
+++ b/core/src/main/scala/sec/position.scala
@@ -80,7 +80,7 @@ object StreamPosition {
 
   val Start: Exact = Exact(ULong.min)
 
-  final case class Exact(value: ULong) extends StreamPosition with StreamState with PositionInfo
+  final case class Exact(value: ULong) extends StreamPosition with StreamState
   object Exact {
     def fromUnsigned(value: Long): Exact = Exact(ULong(value))
   }
@@ -179,36 +179,6 @@ object LogPosition {
       case (0, x) => x
       case (x, _) => x
     }
-  }
-
-}
-
-//======================================================================================================================
-
-sealed trait PositionInfo
-object PositionInfo {
-
-  final case class Global(
-    stream: StreamPosition.Exact,
-    log: LogPosition.Exact
-  ) extends PositionInfo
-
-  type Local = StreamPosition.Exact
-
-  implicit final class PositionOps(val p: PositionInfo) extends AnyVal {
-
-    def fold[A](global: Global => A, local: Local => A): A = p match {
-      case a: Global => global(a)
-      case l: Local  => local(l)
-    }
-
-    def streamPosition: StreamPosition.Exact = fold(_.stream, identity)
-
-    def renderPosition: String = fold(
-      a => s"log: (c = ${a.log.commit.render}, p = ${a.log.prepare.render}), stream: ${a.stream.value.render}",
-      e => s"stream: ${e.value.render}"
-    )
-
   }
 
 }

--- a/docs/types.md
+++ b/docs/types.md
@@ -186,19 +186,14 @@ When `EventType` is translated to the protocol of @esdb@ it becomes `application
 
 ### Event
 
-Event data arriving from @esdb@ either comes from an individual stream or from the global log. Data retrieved 
-from the global log contains positions `LogPosition.Exact` and `StreamPosition.Exact`, whereas data retrieved 
-from an individual stream contains only `StreamPosition.Exact`. 
-
-The difference in position information is encoded in the *ADT* that models an event, `Event[P <: PositionInfo]` where `P` 
-is either `PositionInfo.Global` containing both position types or `PositionInfo.Local` that is an alias for `StreamPosition.Exact`.
-
-`Event` has the variants `EventRecord` and `ResolvedEvent`.
+Event data arriving from @esdb@ either comes from an individual stream or from the global log. An event is encoded as an
+`ADT` called `Event` that has the variants `EventRecord` and `ResolvedEvent`.
 
 An `EventRecord` consists of the following data types:
 
   - `streamId: StreamId` - The stream the event belongs to.
-  - `position: P` - The `PositionInfo` information `P` about the event.
+  - `streamPosition: StreamPosition.Exact` - The stream position of the event in its stream.
+  - `logPosition: LogPosition.Exact` - The position of the event in the global stream.
   - `eventData: EventData` - The data of the event.
   - `created: ZonedDateTime` - The time the event was created.
   

--- a/fs2/src/main/scala-2.13/sec/syntax/streams.scala
+++ b/fs2/src/main/scala-2.13/sec/syntax/streams.scala
@@ -33,11 +33,11 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param exclusiveFrom
     *   position to start from. Use [[None]] to subscribe from the beginning.
     * @return
-    *   a [[Stream]] that emits [[AllEvent]] values.
+    *   a [[Stream]] that emits [[Event]] values.
     */
   def subscribeToAll(
     exclusiveFrom: Option[LogPosition]
-  ): Stream[F, AllEvent] =
+  ): Stream[F, Event] =
     s.subscribeToAll(exclusiveFrom, resolveLinkTos = false)
 
   /** Subscribes to the global stream, [[StreamId.All]] using a subscription filter without resolving
@@ -48,13 +48,13 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param filterOptions
     *   to use when subscribing - See [[sec.api.SubscriptionFilterOptions]].
     * @return
-    *   a [[Stream]] that emits either [[Checkpoint]] or [[AllEvent]] values. How frequent [[Checkpoint]] is emitted
+    *   a [[Stream]] that emits either [[Checkpoint]] or [[Event]] values. How frequent [[Checkpoint]] is emitted
     *   depends on [[filterOptions]].
     */
   def subscribeToAll(
     exclusiveFrom: Option[LogPosition],
     filterOptions: SubscriptionFilterOptions
-  ): Stream[F, Either[Checkpoint, AllEvent]] =
+  ): Stream[F, Either[Checkpoint, Event]] =
     s.subscribeToAll(exclusiveFrom, filterOptions, resolveLinkTos = false)
 
   /** Subscribes to an individual stream without resolving [[EventType.LinkTo]] events.
@@ -64,12 +64,12 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param exclusiveFrom
     *   stream position to start from. Use [[None]] to subscribe from the beginning.
     * @return
-    *   a [[Stream]] that emits [[StreamEvent]] values.
+    *   a [[Stream]] that emits [[Event]] values.
     */
   def subscribeToStream(
     streamId: StreamId,
     exclusiveFrom: Option[StreamPosition]
-  ): Stream[F, StreamEvent] =
+  ): Stream[F, Event] =
     s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos = false)
 
   // / Read
@@ -83,13 +83,13 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param resolveLinkTos
     *   whether to resolve [[EventType.LinkTo]] events automatically.
     * @return
-    *   a [[Stream]] that emits [[AllEvent]] values.
+    *   a [[Stream]] that emits [[Event]] values.
     */
   def readAllForwards(
     from: LogPosition = LogPosition.Start,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, AllEvent] =
+  ): Stream[F, Event] =
     s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos)
 
   /** Read events backwards from the global stream, [[sec.StreamId.All]].
@@ -101,13 +101,13 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param resolveLinkTos
     *   whether to resolve [[EventType.LinkTo]] events automatically.
     * @return
-    *   a [[Stream]] that emits [[AllEvent]] values.
+    *   a [[Stream]] that emits [[Event]] values.
     */
   def readAllBackwards(
     from: LogPosition = LogPosition.End,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, AllEvent] =
+  ): Stream[F, Event] =
     s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos)
 
   /** Read events forwards from an individual stream. A [[sec.api.exceptions.StreamNotFound]] is raised when the stream
@@ -122,14 +122,14 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param resolveLinkTos
     *   whether to resolve [[EventType.LinkTo]] events automatically.
     * @return
-    *   a [[Stream]] that emits [[StreamEvent]] values.
+    *   a [[Stream]] that emits [[Event]] values.
     */
   def readStreamForwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.Start,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, StreamEvent] =
+  ): Stream[F, Event] =
     s.readStream(streamId, from, Direction.Forwards, maxCount, resolveLinkTos)
 
   /** Read events backwards from an individual stream. A [[sec.api.exceptions.StreamNotFound]] is raised when the stream
@@ -144,14 +144,14 @@ final class StreamsOps[F[_]](val s: Streams[F]) extends AnyVal {
     * @param resolveLinkTos
     *   whether to resolve [[EventType.LinkTo]] events automatically.
     * @return
-    *   a [[Stream]] that emits [[StreamEvent]] values.
+    *   a [[Stream]] that emits [[Event]] values.
     */
   def readStreamBackwards(
     streamId: StreamId,
     from: StreamPosition = StreamPosition.End,
     maxCount: Long = Long.MaxValue,
     resolveLinkTos: Boolean = false
-  ): Stream[F, StreamEvent] =
+  ): Stream[F, Event] =
     s.readStream(streamId, from, Direction.Backwards, maxCount, resolveLinkTos)
 
 }

--- a/fs2/src/main/scala-3/sec/syntax/streams.scala
+++ b/fs2/src/main/scala-3/sec/syntax/streams.scala
@@ -31,11 +31,11 @@ trait StreamsSyntax {
       * @param exclusiveFrom
       *   position to start from. Use [[None]] to subscribe from the beginning.
       * @return
-      *   a [[Stream]] that emits [[AllEvent]] values.
+      *   a [[Stream]] that emits [[Event]] values.
       */
     def subscribeToAll(
       exclusiveFrom: Option[LogPosition]
-    ): Stream[F, AllEvent] =
+    ): Stream[F, Event] =
       s.subscribeToAll(exclusiveFrom, resolveLinkTos = false)
 
     /** Subscribes to the global stream, [[StreamId.All]] using a subscription filter without resolving
@@ -46,13 +46,13 @@ trait StreamsSyntax {
       * @param filterOptions
       *   to use when subscribing - See [[sec.api.SubscriptionFilterOptions]].
       * @return
-      *   a [[Stream]] that emits either [[Checkpoint]] or [[AllEvent]] values. How frequent [[Checkpoint]] is emitted
+      *   a [[Stream]] that emits either [[Checkpoint]] or [[Event]] values. How frequent [[Checkpoint]] is emitted
       *   depends on [[filterOptions]].
       */
     def subscribeToAll(
       exclusiveFrom: Option[LogPosition],
       filterOptions: SubscriptionFilterOptions
-    ): Stream[F, Either[Checkpoint, AllEvent]] =
+    ): Stream[F, Either[Checkpoint, Event]] =
       s.subscribeToAll(exclusiveFrom, filterOptions, resolveLinkTos = false)
 
     /** Subscribes to an individual stream without resolving [[EventType.LinkTo]] events.
@@ -62,12 +62,12 @@ trait StreamsSyntax {
       * @param exclusiveFrom
       *   stream position to start from. Use [[None]] to subscribe from the beginning.
       * @return
-      *   a [[Stream]] that emits [[StreamEvent]] values.
+      *   a [[Stream]] that emits [[Event]] values.
       */
     def subscribeToStream(
       streamId: StreamId,
       exclusiveFrom: Option[StreamPosition]
-    ): Stream[F, StreamEvent] =
+    ): Stream[F, Event] =
       s.subscribeToStream(streamId, exclusiveFrom, resolveLinkTos = false)
 
     // / Read
@@ -81,13 +81,13 @@ trait StreamsSyntax {
       * @param resolveLinkTos
       *   whether to resolve [[EventType.LinkTo]] events automatically.
       * @return
-      *   a [[Stream]] that emits [[AllEvent]] values.
+      *   a [[Stream]] that emits [[Event]] values.
       */
     def readAllForwards(
       from: LogPosition = LogPosition.Start,
       maxCount: Long = Long.MaxValue,
       resolveLinkTos: Boolean = false
-    ): Stream[F, AllEvent] =
+    ): Stream[F, Event] =
       s.readAll(from, Direction.Forwards, maxCount, resolveLinkTos)
 
     /** Read events backwards from the global stream, [[sec.StreamId.All]].
@@ -99,13 +99,13 @@ trait StreamsSyntax {
       * @param resolveLinkTos
       *   whether to resolve [[EventType.LinkTo]] events automatically.
       * @return
-      *   a [[Stream]] that emits [[AllEvent]] values.
+      *   a [[Stream]] that emits [[Event]] values.
       */
     def readAllBackwards(
       from: LogPosition = LogPosition.End,
       maxCount: Long = Long.MaxValue,
       resolveLinkTos: Boolean = false
-    ): Stream[F, AllEvent] =
+    ): Stream[F, Event] =
       s.readAll(from, Direction.Backwards, maxCount, resolveLinkTos)
 
     /** Read events forwards from an individual stream. A [[sec.api.exceptions.StreamNotFound]] is raised when the
@@ -120,14 +120,14 @@ trait StreamsSyntax {
       * @param resolveLinkTos
       *   whether to resolve [[EventType.LinkTo]] events automatically.
       * @return
-      *   a [[Stream]] that emits [[StreamEvent]] values.
+      *   a [[Stream]] that emits [[Event]] values.
       */
     def readStreamForwards(
       streamId: StreamId,
       from: StreamPosition = StreamPosition.Start,
       maxCount: Long = Long.MaxValue,
       resolveLinkTos: Boolean = false
-    ): Stream[F, StreamEvent] =
+    ): Stream[F, Event] =
       s.readStream(streamId, from, Direction.Forwards, maxCount, resolveLinkTos)
 
     /** Read events backwards from an individual stream. A [[sec.api.exceptions.StreamNotFound]] is raised when the
@@ -142,14 +142,14 @@ trait StreamsSyntax {
       * @param resolveLinkTos
       *   whether to resolve [[EventType.LinkTo]] events automatically.
       * @return
-      *   a [[Stream]] that emits [[StreamEvent]] values.
+      *   a [[Stream]] that emits [[Event]] values.
       */
     def readStreamBackwards(
       streamId: StreamId,
       from: StreamPosition = StreamPosition.End,
       maxCount: Long = Long.MaxValue,
       resolveLinkTos: Boolean = false
-    ): Stream[F, StreamEvent] =
+    ): Stream[F, Event] =
       s.readStream(streamId, from, Direction.Backwards, maxCount, resolveLinkTos)
 
   }

--- a/tests/src/sit/scala/sec/api/streams/readAll.scala
+++ b/tests/src/sit/scala/sec/api/streams/readAll.scala
@@ -113,7 +113,7 @@ class ReadAllSuite extends SnSuite {
 
       val setup = write >>= { wr => delete(wr.streamPosition).void >> verifyDeleted >> read }
 
-      def verify(es: List[AllEvent]): Unit =
+      def verify(es: List[Event]): Unit =
         es.lastOption.fold(fail("expected metadata")) { ts =>
           if (normalDelete) {
             assertEquals(es.dropRight(1).map(_.eventData), events.toList)

--- a/tests/src/sit/scala/sec/api/streams/reads.scala
+++ b/tests/src/sit/scala/sec/api/streams/reads.scala
@@ -48,7 +48,7 @@ class ReadsSuite extends SnSuite {
           .toList
           .map { ms =>
 
-            val readEvents   = ms.collect { case StreamMessage.Event(e) => e }
+            val readEvents   = ms.collect { case StreamMessage.StreamEvent(e) => e }
             val lastPosition = ms.lastOption.collect { case StreamMessage.LastStreamPosition(l) => l }
 
             assertEquals(ms.size, 33)
@@ -81,7 +81,7 @@ class ReadsSuite extends SnSuite {
 
       result.map { ms =>
 
-        val readEvents   = ms.collect { case StreamMessage.Event(e) => e }
+        val readEvents   = ms.collect { case StreamMessage.StreamEvent(e) => e }
         val lastPosition = ms.lastOption.collect { case StreamMessage.LastStreamPosition(l) => l }
 
         assertEquals(ms.size, 33)
@@ -106,7 +106,7 @@ class ReadsSuite extends SnSuite {
       result.map { ms =>
 
         val firstPosition = ms.headOption.collect { case StreamMessage.FirstStreamPosition(f) => f }
-        val readEvents    = ms.collect { case StreamMessage.Event(e) => e }
+        val readEvents    = ms.collect { case StreamMessage.StreamEvent(e) => e }
         val lastPosition  = ms.lastOption.collect { case StreamMessage.LastStreamPosition(l) => l }
 
         assertEquals(ms.size, 34)

--- a/tests/src/sit/scala/sec/api/streams/subscribeToStream.scala
+++ b/tests/src/sit/scala/sec/api/streams/subscribeToStream.scala
@@ -73,7 +73,7 @@ class SubscribeToStreamSuite extends SnSuite {
       val id    = genStreamId(s"${streamPrefix}multiple_subscriptions_to_same_stream_")
       val write = Stream.eval(streams.appendToStream(id, NoStream, events)).delayBy(1.second)
 
-      def mkSubscribers(onEvent: IO[Unit]): Stream[IO, StreamEvent] = Stream
+      def mkSubscribers(onEvent: IO[Unit]): Stream[IO, Event] = Stream
         .emit(streams.subscribeToStream(id, exclusivFrom).evalTap(_ => onEvent).take(takeCount.toLong))
         .repeat
         .take(subscriberCount.toLong)
@@ -110,7 +110,7 @@ class SubscribeToStreamSuite extends SnSuite {
       def afterWrite(st: StreamState): Stream[IO, WriteResult] =
         Stream.eval(streams.appendToStream(id, st, afterEvents)).delayBy(1.second)
 
-      def subscribe(onEvent: StreamEvent => IO[Unit]): Stream[IO, StreamEvent] =
+      def subscribe(onEvent: Event => IO[Unit]): Stream[IO, Event] =
         streams.subscribeToStream(id, exclusiveFrom).evalTap(onEvent).take(takeCount.toLong)
 
       val result: Stream[IO, List[EventData]] = for {

--- a/tests/src/test/scala/sec/position.scala
+++ b/tests/src/test/scala/sec/position.scala
@@ -81,27 +81,4 @@ class VersionSuite extends SecDisciplineSuite {
     }
   }
 
-  group("PositionInfo") {
-
-    test("renderPosition") {
-
-      val stream = StreamPosition(1L)
-      val all    = PositionInfo.Global(stream, LogPosition.exact(2L, 3L))
-
-      assertEquals((stream: PositionInfo).renderPosition, "stream: 1")
-      assertEquals((all: PositionInfo).renderPosition, "log: (c = 2, p = 3), stream: 1")
-    }
-
-    test("streamPosition") {
-
-      val stream = StreamPosition(1L)
-      val all    = PositionInfo.Global(stream, LogPosition.exact(2L, 3L))
-
-      assertEquals((stream: PositionInfo).streamPosition, StreamPosition(1L))
-      assertEquals((all: PositionInfo).streamPosition, StreamPosition(1L))
-
-    }
-
-  }
-
 }


### PR DESCRIPTION
 - remove position info encoding and stream event / all event.
 - log position is back on event as 22.10.x provides this info.