### PR TITLE
protobuf: change package names

### DIFF
--- a/core/src/main/scala/sec/api/callcontext.scala
+++ b/core/src/main/scala/sec/api/callcontext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/cluster/endpoints.scala
+++ b/core/src/main/scala/sec/api/cluster/endpoints.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/cluster/prioritizer.scala
+++ b/core/src/main/scala/sec/api/cluster/prioritizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/direction.scala
+++ b/core/src/main/scala/sec/api/direction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/endpoint.scala
+++ b/core/src/main/scala/sec/api/endpoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/filter.scala
+++ b/core/src/main/scala/sec/api/filter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/gossip.scala
+++ b/core/src/main/scala/sec/api/gossip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/grpc/constants.scala
+++ b/core/src/main/scala/sec/api/grpc/constants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/grpc/convert.scala
+++ b/core/src/main/scala/sec/api/grpc/convert.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/grpc/marshalling.scala
+++ b/core/src/main/scala/sec/api/grpc/marshalling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/grpc/metadata.scala
+++ b/core/src/main/scala/sec/api/grpc/metadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/mapping/error.scala
+++ b/core/src/main/scala/sec/api/mapping/error.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/mapping/gossip.scala
+++ b/core/src/main/scala/sec/api/mapping/gossip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package mapping
 
 import cats.MonadThrow
 import cats.syntax.all.*
-import com.eventstore.dbclient.proto.gossip as p
+import io.kurrent.dbclient.proto.gossip as p
 import sec.api.mapping.shared.*
 import sec.api.mapping.time.*
 

--- a/core/src/main/scala/sec/api/mapping/package.scala
+++ b/core/src/main/scala/sec/api/mapping/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/mapping/shared.scala
+++ b/core/src/main/scala/sec/api/mapping/shared.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ package mapping
 import java.util.UUID as JUUID
 import cats.{ApplicativeThrow, MonadThrow}
 import cats.syntax.all.*
-import com.eventstore.dbclient.proto.shared as ps
+import io.kurrent.dbclient.proto.shared as ps
 import com.google.protobuf.ByteString
 import exceptions.{MaximumAppendSizeExceeded, StreamDeleted, WrongExpectedState}
 

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeoutException
 import cats.{Applicative, ApplicativeThrow, MonadThrow}
 import cats.data.{NonEmptyList, OptionT}
 import cats.syntax.all.*
-import com.eventstore.dbclient.proto.shared as pshared
-import com.eventstore.dbclient.proto.streams.*
+import io.kurrent.dbclient.proto.shared as pshared
+import io.kurrent.dbclient.proto.streams.*
 import sec.api.exceptions.*
 import sec.api.grpc.constants.Metadata.{ContentType, ContentTypes, Created, Type}
 import sec.api.mapping.shared.*

--- a/core/src/main/scala/sec/api/mapping/time.scala
+++ b/core/src/main/scala/sec/api/mapping/time.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/options.scala
+++ b/core/src/main/scala/sec/api/options.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/preference.scala
+++ b/core/src/main/scala/sec/api/preference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/api/streams.scala
+++ b/core/src/main/scala/sec/api/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/error.scala
+++ b/core/src/main/scala/sec/error.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/event.scala
+++ b/core/src/main/scala/sec/event.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/id.scala
+++ b/core/src/main/scala/sec/id.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/metadata.scala
+++ b/core/src/main/scala/sec/metadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/package.scala
+++ b/core/src/main/scala/sec/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/position.scala
+++ b/core/src/main/scala/sec/position.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/sec/utilities.scala
+++ b/core/src/main/scala/sec/utilities.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2-netty/src/main/scala/sec/api/netty.scala
+++ b/fs2-netty/src/main/scala/sec/api/netty.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2-netty/src/main/scala/sec/api/package.scala
+++ b/fs2-netty/src/main/scala/sec/api/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/builder.scala
+++ b/fs2/src/main/scala/sec/api/builder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/channel.scala
+++ b/fs2/src/main/scala/sec/api/channel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/client.scala
+++ b/fs2/src/main/scala/sec/api/client.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import cats.syntax.all.*
 import cats.data.NonEmptySet
 import cats.effect.{Async, Resource}
 import com.comcast.ip4s.{Hostname, Port}
-import com.eventstore.dbclient.proto.gossip.GossipFs2Grpc
-import com.eventstore.dbclient.proto.streams.StreamsFs2Grpc
+import io.kurrent.dbclient.proto.gossip.GossipFs2Grpc
+import io.kurrent.dbclient.proto.streams.StreamsFs2Grpc
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.noop.NoOpLogger
 import io.grpc.{CallOptions, ManagedChannel}

--- a/fs2/src/main/scala/sec/api/cluster/dns.scala
+++ b/fs2/src/main/scala/sec/api/cluster/dns.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/cluster/notifier.scala
+++ b/fs2/src/main/scala/sec/api/cluster/notifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/cluster/resolver.scala
+++ b/fs2/src/main/scala/sec/api/cluster/resolver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/cluster/watch.scala
+++ b/fs2/src/main/scala/sec/api/cluster/watch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/gossip.scala
+++ b/fs2/src/main/scala/sec/api/gossip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package api
 
 import cats.syntax.all.*
 import cats.effect.Temporal
-import com.eventstore.dbclient.proto.gossip.{ClusterInfo as PClusterInfo, GossipFs2Grpc}
-import com.eventstore.dbclient.proto.shared.Empty
+import io.kurrent.dbclient.proto.gossip.{ClusterInfo as PClusterInfo, GossipFs2Grpc}
+import io.kurrent.dbclient.proto.shared.Empty
 import sec.api.mapping.gossip.mkClusterInfo
 
 /** API for reading gossip information from an KurrentDB cluster.

--- a/fs2/src/main/scala/sec/api/metastreams.scala
+++ b/fs2/src/main/scala/sec/api/metastreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/opts.scala
+++ b/fs2/src/main/scala/sec/api/opts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/retries.scala
+++ b/fs2/src/main/scala/sec/api/retries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import cats.*
 import cats.data.*
 import cats.effect.*
 import cats.syntax.all.*
-import com.eventstore.dbclient.proto.streams.*
+import io.kurrent.dbclient.proto.streams.*
 import fs2.{Pipe, Pull, Stream}
 import org.typelevel.log4cats.Logger
 import sec.api.exceptions.{ResubscriptionRequired, WrongExpectedVersion}

--- a/fs2/src/main/scala/sec/api/streams/reads.scala
+++ b/fs2/src/main/scala/sec/api/streams/reads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ package streams
 import cats.syntax.all.*
 import cats.effect.Temporal
 import fs2.Stream
-import com.eventstore.dbclient.proto.streams.*
+import io.kurrent.dbclient.proto.streams.*
 import sec.api.mapping.streams.incoming as mi
 import sec.api.mapping.streams.outgoing as mo
 

--- a/fs2/src/main/scala/sec/syntax/all.scala
+++ b/fs2/src/main/scala/sec/syntax/all.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/syntax/api.scala
+++ b/fs2/src/main/scala/sec/syntax/api.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/syntax/metastreams.scala
+++ b/fs2/src/main/scala/sec/syntax/metastreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/syntax/reads.scala
+++ b/fs2/src/main/scala/sec/syntax/reads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/syntax/std.scala
+++ b/fs2/src/main/scala/sec/syntax/std.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fs2/src/main/scala/sec/syntax/streams.scala
+++ b/fs2/src/main/scala/sec/syntax/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/protobuf/gossip.proto
+++ b/protobuf/gossip.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.gossip;
-option java_package = "com.eventstore.dbclient.proto.gossip";
+option java_package = "io.kurrent.dbclient.proto.gossip";
 
 import "shared.proto";
 

--- a/protobuf/shared.proto
+++ b/protobuf/shared.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client;
-option java_package = "com.eventstore.dbclient.proto.shared";
+option java_package = "io.kurrent.dbclient.proto.shared";
 import "google/protobuf/empty.proto";
 
 message UUID {

--- a/protobuf/streams.proto
+++ b/protobuf/streams.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.streams;
-option java_package = "com.eventstore.dbclient.proto.streams";
+option java_package = "io.kurrent.dbclient.proto.streams";
 
 import "shared.proto";
 import "google/rpc/status.proto";

--- a/tests/src/cit/scala/sec/api/cluster.scala
+++ b/tests/src/cit/scala/sec/api/cluster.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/cit/scala/sec/api/csuite.scala
+++ b/tests/src/cit/scala/sec/api/csuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/scala/sec/arbitraries.scala
+++ b/tests/src/main/scala/sec/arbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/scala/sec/helpers.scala
+++ b/tests/src/main/scala/sec/helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/scala/sec/misc.scala
+++ b/tests/src/main/scala/sec/misc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/main/scala/sec/suits.scala
+++ b/tests/src/main/scala/sec/suits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/channel.scala
+++ b/tests/src/sit/scala/sec/api/channel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/gossip.scala
+++ b/tests/src/sit/scala/sec/api/gossip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/metastreams.scala
+++ b/tests/src/sit/scala/sec/api/metastreams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/snsuite.scala
+++ b/tests/src/sit/scala/sec/api/snsuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/append.scala
+++ b/tests/src/sit/scala/sec/api/streams/append.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/delete.scala
+++ b/tests/src/sit/scala/sec/api/streams/delete.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/readAll.scala
+++ b/tests/src/sit/scala/sec/api/streams/readAll.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/readStream.scala
+++ b/tests/src/sit/scala/sec/api/streams/readStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/reads.scala
+++ b/tests/src/sit/scala/sec/api/streams/reads.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/subscribeToAll.scala
+++ b/tests/src/sit/scala/sec/api/streams/subscribeToAll.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/subscribeToAllFilter.scala
+++ b/tests/src/sit/scala/sec/api/streams/subscribeToAllFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/subscribeToStream.scala
+++ b/tests/src/sit/scala/sec/api/streams/subscribeToStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/sit/scala/sec/api/streams/tombstone.scala
+++ b/tests/src/sit/scala/sec/api/streams/tombstone.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/callcontext.scala
+++ b/tests/src/test/scala/sec/api/callcontext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/cluster/notifier.scala
+++ b/tests/src/test/scala/sec/api/cluster/notifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/cluster/prioritizer.scala
+++ b/tests/src/test/scala/sec/api/cluster/prioritizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/cluster/watch.scala
+++ b/tests/src/test/scala/sec/api/cluster/watch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/direction.scala
+++ b/tests/src/test/scala/sec/api/direction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/endpoint.scala
+++ b/tests/src/test/scala/sec/api/endpoint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/filter.scala
+++ b/tests/src/test/scala/sec/api/filter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/gossip.scala
+++ b/tests/src/test/scala/sec/api/gossip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/grpc/convert.scala
+++ b/tests/src/test/scala/sec/api/grpc/convert.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/grpc/marshalling.scala
+++ b/tests/src/test/scala/sec/api/grpc/marshalling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/grpc/metadata.scala
+++ b/tests/src/test/scala/sec/api/grpc/metadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/mapping/gossip.scala
+++ b/tests/src/test/scala/sec/api/mapping/gossip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ package mapping
 import java.time.{Instant, ZoneOffset}
 import java.util.UUID as JUUID
 import cats.syntax.all.*
-import com.eventstore.dbclient.proto.shared.UUID
-import com.eventstore.dbclient.proto.gossip as g
+import io.kurrent.dbclient.proto.shared.UUID
+import io.kurrent.dbclient.proto.gossip as g
 import sec.api.mapping.gossip.*
 
 class GossipMappingSuite extends SecSuite:

--- a/tests/src/test/scala/sec/api/mapping/package.scala
+++ b/tests/src/test/scala/sec/api/mapping/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/mapping/shared.scala
+++ b/tests/src/test/scala/sec/api/mapping/shared.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ package mapping
 import java.util.UUID as JUUID
 import com.google.protobuf.ByteString
 import cats.syntax.all.*
-import com.eventstore.dbclient.proto.shared as ps
+import io.kurrent.dbclient.proto.shared as ps
 import sec.api.exceptions.{MaximumAppendSizeExceeded, StreamDeleted, WrongExpectedState}
 import sec.api.mapping.shared.*
 import sec.helpers.implicits.*

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import java.util.UUID as JUUID
 import cats.data.NonEmptyList
 import cats.syntax.all.*
 import org.scalacheck.Prop.*
-import com.eventstore.dbclient.proto.shared as ps
-import com.eventstore.dbclient.proto.streams as s
+import io.kurrent.dbclient.proto.shared as ps
+import io.kurrent.dbclient.proto.streams as s
 import scodec.bits.ByteVector
 import sec.api.exceptions.{StreamNotFound, WrongExpectedState}
 import sec.api.mapping.shared.*

--- a/tests/src/test/scala/sec/api/mapping/time.scala
+++ b/tests/src/test/scala/sec/api/mapping/time.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/preference.scala
+++ b/tests/src/test/scala/sec/api/preference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/retries.scala
+++ b/tests/src/test/scala/sec/api/retries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/api/streams.scala
+++ b/tests/src/test/scala/sec/api/streams.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/event.scala
+++ b/tests/src/test/scala/sec/event.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/id.scala
+++ b/tests/src/test/scala/sec/id.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/metadata.scala
+++ b/tests/src/test/scala/sec/metadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/position.scala
+++ b/tests/src/test/scala/sec/position.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/tsc/config.scala
+++ b/tests/src/test/scala/sec/tsc/config.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/sec/utilities.scala
+++ b/tests/src/test/scala/sec/utilities.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tsc/src/main/scala/sec/tsc/package.scala
+++ b/tsc/src/main/scala/sec/tsc/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Scala Event Sourcing client for KurrentDB
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
 - change package from `com.eventstore.dbclient.*` to `io.kurrent.dbclient.proto.*` in order to align with new naming in officual client libraries.