### PR TITLE
feat: resubsribe on server-completed subscriptions + confirmation timeout

### DIFF
--- a/core/src/main/scala/sec/api/options.scala
+++ b/core/src/main/scala/sec/api/options.scala
@@ -79,6 +79,8 @@ private[sec] object Options:
     def withOperationsRetryMaxAttempts(max: Int): Options           = modifyOO(_.copy(retryMaxAttempts = max))
     def withOperationsRetryBackoffFactor(factor: Double): Options   = modifyOO(_.copy(retryBackoffFactor = factor))
     def withOperationsRetryEnabled(enabled: Boolean): Options       = modifyOO(_.copy(retryEnabled = enabled))
+    def withSubscriptionConfirmationTimeout(timeout: FiniteDuration): Options =
+      modifyOO(_.copy(subscriptionConfirmationTimeout = timeout))
 
 //======================================================================================================================
 
@@ -133,17 +135,19 @@ final private[sec] case class OperationOptions(
   retryDelay: FiniteDuration,
   retryMaxDelay: FiniteDuration,
   retryBackoffFactor: Double,
-  retryMaxAttempts: Int
+  retryMaxAttempts: Int,
+  subscriptionConfirmationTimeout: FiniteDuration
 )
 
 private[sec] object OperationOptions:
 
   val default: OperationOptions = OperationOptions(
-    retryEnabled       = true,
-    retryDelay         = 250.millis,
-    retryMaxDelay      = 5.seconds,
-    retryBackoffFactor = 1.5,
-    retryMaxAttempts   = 100
+    retryEnabled                    = true,
+    retryDelay                      = 250.millis,
+    retryMaxDelay                   = 5.seconds,
+    retryBackoffFactor              = 1.5,
+    retryMaxAttempts                = 100,
+    subscriptionConfirmationTimeout = 10.seconds
   )
 
 //======================================================================================================================
@@ -215,6 +219,8 @@ private[sec] trait OptionsBuilder[B <: OptionsBuilder[B]]:
   def withOperationsRetryBackoffFactor(value: Double): B    = modOptions(_.withOperationsRetryBackoffFactor(value))
   def withOperationsRetryEnabled: B                         = modOptions(_.withOperationsRetryEnabled(true))
   def withOperationsRetryDisabled: B                        = modOptions(_.withOperationsRetryEnabled(false))
+  def withSubscriptionConfirmationTimeout(value: FiniteDuration): B =
+    modOptions(_.withSubscriptionConfirmationTimeout(value))
 
 //======================================================================================================================
 

--- a/fs2/src/main/scala/sec/api/client.scala
+++ b/fs2/src/main/scala/sec/api/client.scala
@@ -150,7 +150,13 @@ object EsClient:
 
   private[sec] def mkOpts[F[_]](oo: OperationOptions, log: Logger[F], prefix: String): Opts[F] =
     val rc = RetryConfig(oo.retryDelay, oo.retryMaxDelay, oo.retryBackoffFactor, oo.retryMaxAttempts, None)
-    Opts[F](oo.retryEnabled, rc, defaultRetryOn, log.withModifiedString(s => s"$prefix > $s"))
+    Opts[F](
+      oo.retryEnabled,
+      rc,
+      defaultRetryOn,
+      log.withModifiedString(s => s"$prefix > $s"),
+      oo.subscriptionConfirmationTimeout
+    )
 
   /// Streams
 

--- a/fs2/src/main/scala/sec/api/opts.scala
+++ b/fs2/src/main/scala/sec/api/opts.scala
@@ -28,7 +28,8 @@ final private[sec] case class Opts[F[_]](
   retryEnabled: Boolean,
   retryConfig: RetryConfig,
   retryOn: Throwable => Boolean,
-  log: Logger[F]
+  log: Logger[F],
+  subscriptionConfirmationTimeout: FiniteDuration = 10.seconds
 )
 
 private[sec] object Opts:

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -24,7 +24,7 @@ import cats.data.*
 import cats.effect.*
 import cats.syntax.all.*
 import io.kurrent.dbclient.proto.streams.*
-import fs2.{Pipe, Pull, Stream}
+import fs2.{Pipe, Pull, RaiseThrowable, Stream}
 import org.typelevel.log4cats.Logger
 import sec.api.exceptions.{ResubscriptionRequired, WrongExpectedVersion}
 import sec.api.mapping.streams.incoming.*
@@ -314,8 +314,12 @@ object Streams:
     val opName: String                               = "subscribeToAll"
     val pipeLog: Logger[F]                           = opts.log.withModifiedString(m => s"$opName: $m")
     val mkReq: Option[LogPosition] => ReadReq        = mkSubscribeToAllReq(_, resolveLinkTos, None)
-    val sub: Option[LogPosition] => Stream[F, Event] = ef => f(mkReq(ef)).through(subscriptionAllPipe(pipeLog))
-    val fn: Event => Option[LogPosition]             = _.record.logPosition.some
+    val sub: Option[LogPosition] => Stream[F, Event] =
+      ef =>
+        f(mkReq(ef))
+          .through(subscriptionAllPipe(pipeLog, opts.subscriptionConfirmationTimeout))
+          .through(raiseOnServerCompletion(opName))
+    val fn: Event => Option[LogPosition] = _.record.logPosition.some
 
     withRetry(exclusiveFrom, sub, fn, opts, opName, Direction.Forwards)
 
@@ -331,8 +335,12 @@ object Streams:
     val opName: String                           = "subscribeToAllWithFilter"
     val pipeLog: Logger[F]                       = opts.log.withModifiedString(m => s"$opName: $m")
     val mkReq: Option[LogPosition] => ReadReq    = mkSubscribeToAllReq(_, resolveLinkTos, filterOptions.some)
-    val sub: Option[LogPosition] => Stream[F, O] = ef => f(mkReq(ef)).through(subAllFilteredPipe(pipeLog))
-    val fn: O => Option[LogPosition]             = _.fold(_.logPosition, _.record.logPosition).some
+    val sub: Option[LogPosition] => Stream[F, O] =
+      ef =>
+        f(mkReq(ef))
+          .through(subAllFilteredPipe(pipeLog, opts.subscriptionConfirmationTimeout))
+          .through(raiseOnServerCompletion(opName))
+    val fn: O => Option[LogPosition] = _.fold(_.logPosition, _.record.logPosition).some
 
     withRetry(exclusiveFrom, sub, fn, opts, opName, Direction.Forwards)
 
@@ -347,7 +355,11 @@ object Streams:
     val pipeLog: Logger[F]                       = opts.log.withModifiedString(m => s"$opName[${streamId.render}]: $m")
     val mkReq: Option[StreamPosition] => ReadReq = mkSubscribeToStreamReq(streamId, _, resolveLinkTos)
 
-    val sub: Option[StreamPosition] => Stream[F, Event] = ef => f(mkReq(ef)).through(subscriptionStreamPipe(pipeLog))
+    val sub: Option[StreamPosition] => Stream[F, Event] =
+      ef =>
+        f(mkReq(ef))
+          .through(subscriptionStreamPipe(pipeLog, opts.subscriptionConfirmationTimeout))
+          .through(raiseOnServerCompletion(opName))
 
     val fn: Event => Option[StreamPosition] = _.record.streamPosition.some
 
@@ -386,42 +398,77 @@ object Streams:
 
 //======================================================================================================================
 
-  private[sec] def subConfirmationPipe[F[_]: MonadThrow](logger: Logger[F]): Pipe[F, ReadResp, ReadResp] = in =>
+  /** The subscription confirmation is the one message the server is guaranteed to send immediately on every
+    * subscription. Not receiving it within `confirmationTimeout` means the subscription was never established, e.g. the
+    * request got in during a node shutdown or role change and the server accepted the call but will never feed it. This
+    * is turned into [[ResubscriptionRequired]], which subscription retry options resume from. After the confirmation
+    * the timeout no longer applies, as a quiet stream is legitimately silent.
+    */
+  private[sec] def subConfirmationPipe[F[_]: Temporal](
+    logger: Logger[F],
+    confirmationTimeout: FiniteDuration
+  ): Pipe[F, ReadResp, ReadResp] = in =>
 
     val log: SubscriptionConfirmation => F[Unit] =
       sc => logger.debug(s"$sc received")
 
-    val initialPull = in.pull.uncons1.flatMap {
-      case Some((h, t)) => Pull.eval(reqConfirmation[F](h) >>= log) >> t.pull.echo
-      case None         => Pull.done
-    }
+    val raiseTimeout: Pull[F, Nothing, Unit] =
+      Pull.raiseError[F](ResubscriptionRequired(s"no subscription confirmation received within $confirmationTimeout"))
 
-    initialPull.stream
+    def echo(tp: Pull.Timed[F, ReadResp]): Pull[F, ReadResp, Unit] =
+      tp.uncons.flatMap {
+        case Some((Right(c), next)) => Pull.output(c) >> echo(next)
+        case Some((Left(_), next))  => echo(next) // stray timeout after confirmation, ignore
+        case None                   => Pull.done
+      }
 
-  private[sec] def subscriptionAllPipe[F[_]: MonadThrow](
-    log: Logger[F]
+    def awaitConfirmation(tp: Pull.Timed[F, ReadResp]): Pull[F, ReadResp, Unit] =
+      tp.uncons.flatMap {
+        case Some((Right(c), next)) =>
+          if c.nonEmpty then Pull.eval(reqConfirmation[F](c(0)) >>= log) >> Pull.output(c.drop(1)) >> echo(next)
+          else awaitConfirmation(next)
+        case Some((Left(_), _)) => raiseTimeout
+        case None               => Pull.done
+      }
+
+    in.pull.timed(tp => tp.timeout(confirmationTimeout) >> awaitConfirmation(tp)).stream
+
+  private[sec] def subscriptionAllPipe[F[_]: Temporal](
+    log: Logger[F],
+    confirmationTimeout: FiniteDuration
   ): Pipe[F, ReadResp, Event] =
     _.filterNot(_.isCheckpoint)
-      .through(subConfirmationPipe(log))
+      .through(subConfirmationPipe(log, confirmationTimeout))
       .through(_.filter(_.isEvent).evalMap(reqReadEvent[F]).unNone)
 
-  private[sec] def subscriptionStreamPipe[F[_]: MonadThrow](
-    log: Logger[F]
+  private[sec] def subscriptionStreamPipe[F[_]: Temporal](
+    log: Logger[F],
+    confirmationTimeout: FiniteDuration
   ): Pipe[F, ReadResp, Event] =
-    _.through(subConfirmationPipe(log))
+    _.through(subConfirmationPipe(log, confirmationTimeout))
       .through(_.filter(_.isEvent).evalMap(reqReadEvent[F]).unNone)
 
-  private[sec] def subAllFilteredPipe[F[_]: MonadThrow](
-    log: Logger[F]
+  private[sec] def subAllFilteredPipe[F[_]: Temporal](
+    log: Logger[F],
+    confirmationTimeout: FiniteDuration
   ): Pipe[F, ReadResp, Either[Checkpoint, Event]] =
     // Defensive filtering to guard against ESDB emitting checkpoints
     // with `LogPosition.Exact.MaxValue`, i.e. end of stream.
-    _.through(subConfirmationPipe(log))
+    _.through(subConfirmationPipe(log, confirmationTimeout))
       .through(_.filter(_.isCheckpointOrEvent).evalMap(mkCheckpointOrEvent[F]).unNone)
       .collect {
         case r @ Right(_)                               => r
         case l @ Left(v) if v != Checkpoint.endOfStream => l
       }
+
+  /** Subscriptions are conceptually infinite: the server never legitimately completes one. A normal completion means
+    * the server dropped the subscription without an error (e.g. node shutdown or leader change during a rolling
+    * restart), so it is turned into [[ResubscriptionRequired]], which subscription retry options resume from by
+    * resubscribing at the last observed position. Client-side cancellation is unaffected as an interrupted stream never
+    * evaluates the appended raise.
+    */
+  private[sec] def raiseOnServerCompletion[F[_]: RaiseThrowable, O](opName: String): Pipe[F, O, O] =
+    _ ++ Stream.raiseError[F](ResubscriptionRequired(s"$opName: server completed the subscription"))
 
   private[sec] def withRetry[F[_]: Temporal, T: Order, O](
     from: T,

--- a/tests/src/test/scala/sec/api/streams.scala
+++ b/tests/src/test/scala/sec/api/streams.scala
@@ -27,6 +27,7 @@ import org.typelevel.log4cats.noop.NoOpLogger
 import org.typelevel.log4cats.testing.TestingLogger
 import sec.api.Direction.Forwards
 import sec.api.Streams.*
+import sec.api.exceptions.ResubscriptionRequired
 import sec.api.retries.RetryConfig
 
 class StreamsWithRetrySuite extends SecEffectSuite:
@@ -145,6 +146,62 @@ class StreamsWithRetrySuite extends SecEffectSuite:
     }
 
     TestControl.executeEmbed(program).map(assertEquals(_, List(0)))
+  }
+
+  test("raiseOnServerCompletion turns normal completion into ResubscriptionRequired") {
+
+    val result = Stream
+      .emits(List(1, 2))
+      .covary[IO]
+      .through(raiseOnServerCompletion("sub"))
+      .attempt
+      .compile
+      .toList
+
+    result.map { r =>
+      assertEquals(r.init, List(Right(1), Right(2)))
+      assert(r.last.fold(_.isInstanceOf[ResubscriptionRequired], _ => false))
+    }
+  }
+
+  test("raiseOnServerCompletion does not fire on client-side cancellation") {
+
+    val program = Stream
+      .never[IO]
+      .through(raiseOnServerCompletion[IO, Unit]("sub"))
+      .interruptAfter(100.millis)
+      .compile
+      .drain
+
+    TestControl.executeEmbed(program)
+  }
+
+  test("resubscribes from last observed position when the server completes a subscription") {
+
+    val config = RetryConfig(
+      delay         = 100.millis,
+      maxDelay      = 500.millis,
+      backoffFactor = 1,
+      maxAttempts   = 3,
+      timeout       = None
+    )
+
+    val opts = Opts[IO](retryEnabled = true, config, _.isInstanceOf[ResubscriptionRequired], NoOpLogger.impl[IO])
+
+    // The server completes the subscription stream normally twice, the third subscription stays live. Elements must
+    // resume after the last observed position with nothing lost or duplicated.
+    val program = IO.ref(0).flatMap { calls =>
+      val source: Option[Int] => Stream[IO, Int] = from =>
+        Stream.eval(calls.updateAndGet(_ + 1)).flatMap { n =>
+          val next = from.fold(1)(_ + 1)
+          val live = Stream.emits(List(next, next + 1)).covary[IO]
+          if n < 3 then live.through(raiseOnServerCompletion("sub"))
+          else (live ++ Stream.never[IO]).through(raiseOnServerCompletion("sub"))
+        }
+      withRetry[IO, Option[Int], Int](None, source, Some(_), opts, "sub", Forwards).take(6).compile.toList
+    }
+
+    TestControl.executeEmbed(program).map(assertEquals(_, List(1, 2, 3, 4, 5, 6)))
   }
 
   test("retryOn") {
@@ -367,6 +424,50 @@ class StreamsWithRetrySuite extends SecEffectSuite:
       b1 *> b2 *> b3 *> b4
 
     }
+  }
+
+class SubConfirmationPipeSuite extends SecEffectSuite:
+
+  import io.kurrent.dbclient.proto.streams as s
+
+  val confirmation: s.ReadResp = s.ReadResp().withConfirmation(s.ReadResp.SubscriptionConfirmation("sub-id"))
+  val other: s.ReadResp        = s.ReadResp()
+
+  def pipe(timeout: FiniteDuration): fs2.Pipe[IO, s.ReadResp, s.ReadResp] =
+    subConfirmationPipe[IO](NoOpLogger.impl[IO], timeout)
+
+  test("consumes the confirmation and echoes the remainder") {
+
+    val in = Stream.emits(List(confirmation, other, other)).covary[IO]
+
+    assertIO(in.through(pipe(1.second)).compile.toList, List(other, other))
+  }
+
+  test("raises ResubscriptionRequired when no confirmation arrives within the timeout") {
+
+    val in: Stream[IO, s.ReadResp] = Stream.never[IO]
+
+    val program = in.through(pipe(1.second)).compile.drain.attempt
+
+    TestControl.executeEmbed(program).map(r => assert(r.swap.exists(_.isInstanceOf[ResubscriptionRequired])))
+  }
+
+  test("raises ResubscriptionRequired when the confirmation arrives after the timeout") {
+
+    val in = Stream.sleep_[IO](2.seconds) ++ Stream.emit(confirmation)
+
+    val program = in.through(pipe(1.second)).compile.drain.attempt
+
+    TestControl.executeEmbed(program).map(r => assert(r.swap.exists(_.isInstanceOf[ResubscriptionRequired])))
+  }
+
+  test("does not time out after confirmation on a quiet stream") {
+
+    val in = Stream.emit(confirmation) ++ Stream.sleep_[IO](1.hour) ++ Stream.emit(other)
+
+    val program = in.through(pipe(1.second)).compile.toList
+
+    TestControl.executeEmbed(program).map(assertEquals(_, List(other)))
   }
 
 object StreamsSpec:

--- a/tests/src/test/scala/sec/tsc/config.scala
+++ b/tests/src/test/scala/sec/tsc/config.scala
@@ -304,7 +304,9 @@ class ConfigSuite extends SecSuite:
           |     retry-max-delay      = 5s
           |     retry-backoff-factor = 2
           |     retry-max-attempts   = 1000
-          |     
+          |
+          |     subscription-confirmation-timeout = 30s
+          |
           |   }
           | }
           |""".stripMargin
@@ -323,6 +325,7 @@ class ConfigSuite extends SecSuite:
         .withOperationsRetryMaxDelay(5.seconds)
         .withOperationsRetryBackoffFactor(2)
         .withOperationsRetryMaxAttempts(1000)
+        .withSubscriptionConfirmationTimeout(30.seconds)
 
       assertEquals(mkOptions[ErrorOr](cfg), Right(expected))
 

--- a/tsc/src/main/resources/reference.conf
+++ b/tsc/src/main/resources/reference.conf
@@ -26,6 +26,8 @@
 #       retry-backoff-factor = 1.5
 #       retry-max-attempts   = 100
 #
+#       subscription-confirmation-timeout = 10s  # max wait for the server to confirm a subscription
+#
 #     }
 #
 #     cluster {

--- a/tsc/src/main/scala/sec/tsc/package.scala
+++ b/tsc/src/main/scala/sec/tsc/package.scala
@@ -181,7 +181,11 @@ private[sec] object config:
       o => cfg.durationOpt(s"$ooPath.retry-delay").fold(o)(o.withOperationsRetryDelay),
       o => cfg.durationOpt(s"$ooPath.retry-max-delay").fold(o)(o.withOperationsRetryMaxDelay),
       o => cfg.option(s"$ooPath.retry-backoff-factor", _.getDouble).fold(o)(o.withOperationsRetryBackoffFactor),
-      o => cfg.option(s"$ooPath.retry-max-attempts", _.getInt).fold(o)(o.withOperationsRetryMaxAttempts)
+      o => cfg.option(s"$ooPath.retry-max-attempts", _.getInt).fold(o)(o.withOperationsRetryMaxAttempts),
+      o =>
+        cfg
+          .durationOpt(s"$ooPath.subscription-confirmation-timeout")
+          .fold(o)(o.withSubscriptionConfirmationTimeout)
     )
 
     val mod = modifications.foldK


### PR DESCRIPTION
Close the remaining silent-stall paths for subscriptions; keepalive covers dead transports, these cover the server ending or never establishing a subscription without an error.

- raiseOnServerCompletion: subscriptions are conceptually infinite, so a normal server-side completion (e.g. node shutdown or leader change during a rolling restart) is turned into ResubscriptionRequired, which withRetry resumes from at the last observed position. With retry disabled the error now surfaces instead of silent completion.

- subConfirmationPipe: bounded wait for the subscription confirmation via a timed first pull; not receiving it within the window (default 10s) raises ResubscriptionRequired. After confirmation the timeout is disarmed, a quiet stream is legitimately silent. Exposed via Options, builders, and tsc config (operations.subscription-confirmation-timeout).