### PR TITLE
perf: refresh cluster topology immediately on NotLeader

### DIFF
--- a/fs2/src/main/scala/sec/api/builder.scala
+++ b/fs2/src/main/scala/sec/api/builder.scala
@@ -26,6 +26,7 @@ import org.typelevel.log4cats.Logger
 import io.grpc.{ManagedChannel, ManagedChannelBuilder, NameResolverRegistry}
 import sec.api.channel.*
 import sec.api.cluster.*
+import sec.api.exceptions.NotLeader
 
 //======================================================================================================================
 
@@ -171,9 +172,16 @@ class ClusterBuilder[F[_]] private (
         val mods: Endo[MCB] =
           _.defaultLoadBalancingPolicy("round_robin").overrideAuthority(authority)
 
+        // A NotLeader observed by an operation means cluster topology is stale, so ask the
+        // watch for an immediate gossip fetch instead of awaiting the notification interval.
+        val refreshHint: Throwable => F[Unit] = {
+          case _: NotLeader => cw.refresh
+          case _            => F.unit
+        }
+
         mkProvider >>= builder >>= { b =>
           channel.resource[F](mods(b).build, options.channelShutdownAwait) >>= { mc =>
-            EsClient[F](mc, options, clusterOptions.preference.isLeader, logger)
+            EsClient[F](mc, options, clusterOptions.preference.isLeader, logger, refreshHint.some)
           }
         }
 

--- a/fs2/src/main/scala/sec/api/client.scala
+++ b/fs2/src/main/scala/sec/api/client.scala
@@ -111,10 +111,11 @@ object EsClient:
     mc: ManagedChannel,
     options: Options,
     requiresLeader: Boolean,
-    logger: Logger[F]
+    logger: Logger[F],
+    refreshHint: Option[Throwable => F[Unit]] = None
   ): Resource[F, EsClient[F]] =
     (mkStreamsFs2Grpc[F](mc, options.prefetchN), mkGossipFs2Grpc[F](mc)).mapN { (s, g) =>
-      create[F](s, g, options, requiresLeader, logger)
+      create[F](s, g, options, requiresLeader, logger, refreshHint)
     }
 
   private[sec] def create[F[_]: Async](
@@ -122,13 +123,14 @@ object EsClient:
     gossipFs2Grpc: GossipFs2Grpc[F, Context],
     options: Options,
     requiresLeader: Boolean,
-    logger: Logger[F]
+    logger: Logger[F],
+    refreshHint: Option[Throwable => F[Unit]] = None
   ): EsClient[F] = new EsClient[F]:
 
     val streams: Streams[F] = Streams(
       streamsFs2Grpc,
       mkContext(options, requiresLeader),
-      mkOpts[F](options.operationOptions, logger, "Streams")
+      mkOpts[F](options.operationOptions, logger, "Streams", refreshHint)
     )
 
     val metaStreams: MetaStreams[F] = MetaStreams[F](streams)
@@ -136,7 +138,7 @@ object EsClient:
     val gossip: Gossip[F] = Gossip(
       gossipFs2Grpc,
       mkContext(options, requiresLeader),
-      mkOpts[F](options.operationOptions, logger, "Gossip")
+      mkOpts[F](options.operationOptions, logger, "Gossip", refreshHint)
     )
 
 //======================================================================================================================
@@ -148,14 +150,20 @@ object EsClient:
     case _: ServerUnavailable | _: NotLeader => true
     case _                                   => false
 
-  private[sec] def mkOpts[F[_]](oo: OperationOptions, log: Logger[F], prefix: String): Opts[F] =
+  private[sec] def mkOpts[F[_]](
+    oo: OperationOptions,
+    log: Logger[F],
+    prefix: String,
+    refreshHint: Option[Throwable => F[Unit]] = None
+  ): Opts[F] =
     val rc = RetryConfig(oo.retryDelay, oo.retryMaxDelay, oo.retryBackoffFactor, oo.retryMaxAttempts, None)
     Opts[F](
       oo.retryEnabled,
       rc,
       defaultRetryOn,
       log.withModifiedString(s => s"$prefix > $s"),
-      oo.subscriptionConfirmationTimeout
+      oo.subscriptionConfirmationTimeout,
+      refreshHint
     )
 
   /// Streams

--- a/fs2/src/main/scala/sec/api/cluster/watch.scala
+++ b/fs2/src/main/scala/sec/api/cluster/watch.scala
@@ -22,6 +22,7 @@ import scala.concurrent.duration.*
 import cats.data.*
 import cats.syntax.all.*
 import cats.effect.*
+import cats.effect.std.Queue
 import com.comcast.ip4s.*
 import fs2.Stream
 import org.typelevel.log4cats.Logger
@@ -32,6 +33,11 @@ import sec.api.channel.*
 
 private[sec] trait ClusterWatch[F[_]]:
   def subscribe: Stream[F, ClusterInfo]
+
+  /** Requests an immediate gossip fetch instead of waiting for the next notification interval, e.g. when an operation
+    * observed [[NotLeader]] and cluster topology is likely stale. Coalesced, non-blocking and safe to call often.
+    */
+  def refresh: F[Unit]
 
 private[sec] object ClusterWatch:
 
@@ -85,7 +91,7 @@ private[sec] object ClusterWatch:
 
     for
       store    <- mkCache
-      updates   = mkWatch(store.get, clusterOptions.notificationInterval).subscribe
+      updates   = mkWatch(store.get, clusterOptions.notificationInterval, Async[F].unit).subscribe
       provider <- mkProvider(updates)
       channel  <- mkChannel(provider)
       gossip   <- gossipFn(channel)
@@ -98,31 +104,36 @@ private[sec] object ClusterWatch:
     store: Cache[F],
     log: Logger[F]
   ): Resource[F, ClusterWatch[F]] =
+    Resource.eval(Queue.bounded[F, Unit](1)) >>= { rq =>
 
-    val watch   = mkWatch(store.get, options.notificationInterval)
-    val fetcher = mkFetcher(readFn, options, store.set, log)
-    val create  = Stream.emit(watch).concurrently(fetcher)
+      val watch   = mkWatch(store.get, options.notificationInterval, rq.tryOffer(()).void)
+      val fetcher = mkFetcher(readFn, options, store.set, Stream.fromQueueUnterminated(rq), log)
+      val create  = Stream.emit(watch).concurrently(fetcher)
 
-    create.compile.resource.lastOrError
+      create.compile.resource.lastOrError
+    }
 
-  def mkWatch[F[_]: Temporal](get: F[ClusterInfo], interval: FiniteDuration): ClusterWatch[F] =
+  def mkWatch[F[_]: Temporal](get: F[ClusterInfo], interval: FiniteDuration, refreshSignal: F[Unit]): ClusterWatch[F] =
     new ClusterWatch[F]:
       val subscribe: Stream[F, ClusterInfo] = Stream.eval(get).metered(interval).repeat.changes
+      val refresh: F[Unit]                  = refreshSignal
 
   def mkFetcher[F[_]: Async](
     readFn: F[ClusterInfo],
     co: ClusterOptions,
     setInfo: ClusterInfo => F[Unit],
+    refreshRequests: Stream[F, Unit],
     log: Logger[F]
   ): Stream[F, Unit] =
-    import co._
 
     val action = retry(readFn, "gossip", retryConfig(co), log) {
       case _: Timeout | _: ServerUnavailable | _: NotLeader => true
       case _                                                => false
     }
 
-    Stream.eval(action).metered(notificationInterval).repeat.changes.evalMap(setInfo)
+    val ticks = Stream.fixedDelay[F](co.notificationInterval).merge(refreshRequests)
+
+    ticks.evalMap(_ => action).changes.evalMap(setInfo)
 
   ///
 

--- a/fs2/src/main/scala/sec/api/opts.scala
+++ b/fs2/src/main/scala/sec/api/opts.scala
@@ -18,6 +18,7 @@ package sec
 package api
 
 import scala.concurrent.duration.*
+import cats.syntax.all.*
 import cats.effect.Temporal
 import org.typelevel.log4cats.Logger
 import sec.api.retries.*
@@ -29,15 +30,23 @@ final private[sec] case class Opts[F[_]](
   retryConfig: RetryConfig,
   retryOn: Throwable => Boolean,
   log: Logger[F],
-  subscriptionConfirmationTimeout: FiniteDuration = 10.seconds
+  subscriptionConfirmationTimeout: FiniteDuration = 10.seconds,
+  // Notified of errors observed by retrying operations, e.g. so the cluster layer
+  // can refresh stale topology immediately when a NotLeader is seen. Must not raise.
+  refreshHint: Option[Throwable => F[Unit]] = None
 )
 
 private[sec] object Opts:
 
   extension [F[_]](opts: Opts[F])
 
+    def hint(t: Throwable)(using F: Temporal[F]): F[Unit] =
+      opts.refreshHint.fold(F.unit)(f => f(t).attempt.void)
+
     def run[A](fa: F[A], opName: String)(using F: Temporal[F]): F[A] =
-      if opts.retryEnabled then retry[F, A](fa, opName, opts.retryConfig, opts.log)(opts.retryOn) else fa
+      if opts.retryEnabled then
+        retry[F, A](fa.onError { case t => opts.hint(t) }, opName, opts.retryConfig, opts.log)(opts.retryOn)
+      else fa
 
     def logWarn(opName: String)(attempt: Int, delay: FiniteDuration, error: Throwable): F[Unit] =
       retries.logWarn(opts.retryConfig, opName, opts.log)(attempt, delay, error)

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -510,6 +510,7 @@ object Streams:
                 // maxDelay window, so maxAttempts bounds *consecutive* fast failures rather than reconnects over a lifetime.
                 val decide: F[(Int, FiniteDuration, T)] =
                   for
+                    _       <- o.hint(t)
                     endedAt <- Temporal[F].monotonic
                     current <- state.get.map(_.getOrElse(f))
                   yield

--- a/tests/src/test/scala/sec/api/cluster/watch.scala
+++ b/tests/src/test/scala/sec/api/cluster/watch.scala
@@ -123,6 +123,30 @@ class ClusterWatchSuite extends SecEffectSuite with TestInstances:
 
     }
 
+    test("refresh triggers an immediate gossip fetch") {
+
+      val options = ClusterOptions.default
+        .withNotificationInterval(10.minutes)
+
+      val program = for
+        counterRef <- IO.ref(0)
+        storeRef   <- IO.ref(List.empty[ClusterInfo])
+        log        <- mkLog
+        readFn      = counterRef.update(_ + 1) *> IO(ClusterInfo(Set.empty))
+        result     <- ClusterWatch.create[IO](readFn, options, recordingCache(storeRef), log).use { w =>
+                    for
+                      _  <- IO.sleep(1.second)
+                      c0 <- counterRef.get // no fetch before the first notification interval
+                      _  <- w.refresh
+                      _  <- IO.sleep(1.second)
+                      c1 <- counterRef.get // refresh caused a fetch well before the interval
+                    yield (c0, c1)
+                  }
+      yield result
+
+      TestControl.executeEmbed(program).map(assertEquals(_, (0, 1)))
+    }
+
     test("retry retriable error using retry delay for backoff") {
 
       val options = ClusterOptions.default

--- a/tests/src/test/scala/sec/api/streams.scala
+++ b/tests/src/test/scala/sec/api/streams.scala
@@ -148,6 +148,41 @@ class StreamsWithRetrySuite extends SecEffectSuite:
     TestControl.executeEmbed(program).map(assertEquals(_, List(0)))
   }
 
+  test("invokes refreshHint on retried errors") {
+
+    val config = RetryConfig(
+      delay         = 100.millis,
+      maxDelay      = 500.millis,
+      backoffFactor = 1,
+      maxAttempts   = 3,
+      timeout       = None
+    )
+
+    val program = for
+      hints <- IO.ref(List.empty[Throwable])
+      opts   = Opts[IO](
+                 retryEnabled = true,
+                 config,
+                 _ => true,
+                 NoOpLogger.impl[IO],
+                 refreshHint = Some(t => hints.update(_ :+ t))
+               )
+      calls <- IO.ref(0)
+      source = (_: Int) =>
+                 Stream.eval(calls.updateAndGet(_ + 1)).flatMap { n =>
+                   if n == 1 then Stream.raiseError[IO](RetryErr()) else Stream.emit(n)
+                 }
+      r     <- withRetry[IO, Int, Int](0, source, identity, opts, "with-retry", Forwards).compile.toList
+      h     <- hints.get
+    yield (r, h)
+
+    TestControl.executeEmbed(program).map { case (r, h) =>
+      assertEquals(r, List(2))
+      assertEquals(h.size, 1)
+      assert(h.head.isInstanceOf[RetryErr])
+    }
+  }
+
   test("raiseOnServerCompletion turns normal completion into ResubscriptionRequired") {
 
     val result = Stream


### PR DESCRIPTION
A NotLeader observed by an operation means the resolver is targeting stale topology; previously retries kept bouncing off the old node until the next gossip poll picked up the new leader. ClusterWatch now exposes a coalescing refresh hook that triggers an immediate gossip fetch, and retrying operations and subscriptions notify it through a refresh hint on their options. Purely internal - no API changes, the hint never raises, and single-node clients are unaffected.