### PR TITLE
Subscription pool requires explicit opt-in via config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -64,7 +64,7 @@ the pool is configured as follows:
 
 ```hocon
 sec.subscription-pool {
-  enabled             = true      # kill-switch, default true
+  enabled             = true      # required - the pool is off by default
   streams-per-channel = 100      # required - the pool stays off without it
   limit               = bounded  # bounded | unbounded
   max-channels        = 10       # used when limit = bounded
@@ -72,8 +72,10 @@ sec.subscription-pool {
 }
 ```
 
-The pool only activates when `streams-per-channel` is present. `enabled = false` is an operational kill-switch: it
-turns the pool off - restoring single-channel behavior - without having to remove the rest of the section.
+The pool is disabled by default: it only activates when both `enabled = true` and `streams-per-channel` are present.
+An absent `sec.subscription-pool` section means no pool. Setting `enabled = false` doubles as an operational
+kill-switch: it turns the pool off - restoring single-channel behavior - without having to remove the rest of the
+section.
 
 While a pool is active, @libName@ also observes the regular channel and warns when its in-flight calls approach
 `streams-per-channel`, since sustained saturation there usually indicates a long-lived read that belongs on a

--- a/tests/src/test/scala/sec/tsc/config.scala
+++ b/tests/src/test/scala/sec/tsc/config.scala
@@ -398,6 +398,7 @@ class ConfigSuite extends SecSuite:
       val cfg1 = ConfigFactory.parseString(
         """
           | sec.subscription-pool {
+          |   enabled             = true
           |   streams-per-channel = 100
           | }
           |""".stripMargin
@@ -408,6 +409,7 @@ class ConfigSuite extends SecSuite:
       val cfg2 = ConfigFactory.parseString(
         """
           | sec.subscription-pool {
+          |   enabled             = true
           |   streams-per-channel = 100
           |   limit               = bounded
           |   max-channels        = 5
@@ -424,6 +426,7 @@ class ConfigSuite extends SecSuite:
       val cfg1 = ConfigFactory.parseString(
         """
           | sec.subscription-pool {
+          |   enabled             = true
           |   streams-per-channel = 100
           |   limit               = unbounded
           | }
@@ -435,6 +438,7 @@ class ConfigSuite extends SecSuite:
       val cfg2 = ConfigFactory.parseString(
         """
           | sec.subscription-pool {
+          |   enabled             = true
           |   streams-per-channel = 100
           |   limit               = unbounded
           |   sanity-cap          = 20
@@ -446,9 +450,18 @@ class ConfigSuite extends SecSuite:
 
     }
 
-    test("enabled = false is the kill-switch") {
+    test("disabled unless explicitly opted in via enabled = true") {
 
-      val cfg = ConfigFactory.parseString(
+      val withoutEnabled = ConfigFactory.parseString(
+        """
+          | sec.subscription-pool {
+          |   streams-per-channel = 100
+          |   max-channels        = 5
+          | }
+          |""".stripMargin
+      )
+
+      val killSwitch = ConfigFactory.parseString(
         """
           | sec.subscription-pool {
           |   enabled             = false
@@ -458,7 +471,8 @@ class ConfigSuite extends SecSuite:
           |""".stripMargin
       )
 
-      assertEquals(mkPoolConfig[ErrorOr](cfg), Right(None))
+      assertEquals(mkPoolConfig[ErrorOr](withoutEnabled), Right(None))
+      assertEquals(mkPoolConfig[ErrorOr](killSwitch), Right(None))
 
     }
 
@@ -467,8 +481,9 @@ class ConfigSuite extends SecSuite:
       def poolCfg(body: String) =
         ConfigFactory.parseString(s"sec.subscription-pool { $body }")
 
-      // a mangled kill-switch must not silently leave the pool running
+      // a mangled switch must not be silently treated as absent, in either direction
       assert(mkPoolConfig[ErrorOr](poolCfg("enabled = flase, streams-per-channel = 100")).isLeft)
+      assert(mkPoolConfig[ErrorOr](poolCfg("enabled = ture, streams-per-channel = 100")).isLeft)
       // a limit typo must not silently fall back to bounded
       assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, limit = unbouned")).isLeft)
       // non-numeric values raise
@@ -489,6 +504,7 @@ class ConfigSuite extends SecSuite:
     val poolCfg =
       """
         | sec.subscription-pool {
+        |   enabled             = true
         |   streams-per-channel = 100
         |   max-channels        = 5
         | }

--- a/tsc/src/main/scala/sec/tsc/package.scala
+++ b/tsc/src/main/scala/sec/tsc/package.scala
@@ -203,18 +203,20 @@ private[sec] object config:
 
   //
 
-  /** The pool only activates when `streams-per-channel` is present: it must mirror the server-side HTTP/2
-    * concurrent-stream limit and deliberately has no default. `enabled = false` is the operational kill-switch: it
-    * turns the pool off without having to remove the rest of the section.
+  /** The pool is disabled unless explicitly opted in: it only activates when `enabled = true` AND `streams-per-channel`
+    * are both present. An absent `sec.subscription-pool` section - or a present one without `enabled = true` - means no
+    * pool. `streams-per-channel` deliberately has no default: it must mirror the server-side HTTP/2 concurrent-stream
+    * limit. Setting `enabled = false` doubles as the operational kill-switch: it turns the pool off without having to
+    * remove the rest of the section.
     *
     * Unlike the other config readers, this one is strict: a malformed value raises instead of being treated as absent.
-    * The kill-switch must not fail open - `enabled = flase` silently leaving the pool running is worse than refusing to
-    * start - and a mangled `streams-per-channel` or `limit` must not silently change the pool's failure mode.
+    * The switch must not misfire silently - `enabled = ture` quietly leaving the pool off, or a mangled
+    * `streams-per-channel` or `limit` silently changing the pool's failure mode, is worse than refusing to start.
     */
   def mkPoolConfig[F[_]: ApplicativeThrow](cfg: Config): F[Option[PoolConfig]] =
 
     val result: Either[Throwable, Option[PoolConfig]] = for
-      enabled <- cfg.strictOption(s"$spPath.enabled", _.getBoolean).map(_.getOrElse(true))
+      enabled <- cfg.strictOption(s"$spPath.enabled", _.getBoolean).map(_.getOrElse(false))
       kind    <- cfg.strictOption(s"$spPath.limit", _.getString).map(_.map(_.trim.toLowerCase).getOrElse("bounded"))
       limit   <- kind match
                  case "bounded" =>
@@ -223,9 +225,11 @@ private[sec] object config:
                    cfg.strictOption(s"$spPath.sanity-cap", _.getInt).map(_.fold(Limit.Unbounded())(Limit.Unbounded(_)))
                  case other =>
                    InvalidInput(s"$spPath.limit must be bounded or unbounded, it was $other.").asLeft
-      spc  <- cfg.strictOption(s"$spPath.streams-per-channel", _.getInt)
-      pool <- spc.filter(_ => enabled).traverse(PoolConfig(_, limit))
-    yield pool
+      spc <- cfg.strictOption(s"$spPath.streams-per-channel", _.getInt)
+      // Everything written in the section is validated even when the pool is not enabled -
+      // a disabled-but-invalid section must fail at startup, not on the day the switch flips.
+      pool <- spc.traverse(PoolConfig(_, limit))
+    yield pool.filter(_ => enabled)
 
     result.liftTo[F]
 


### PR DESCRIPTION
The pool now only activates when both `enabled = true` and `streams-per-channel` are present:

| Configuration | Result |
|---|---|
| No `sec.subscription-pool` section | no pool |
| Section without `enabled` | no pool *(previously: pool active if `streams-per-channel` present)* |
| `enabled = true` + `streams-per-channel` | pool active |
| `enabled = false` | no pool (kill-switch, unchanged) |
| `enabled = ture` / `flase` (typo) | raises at construction - a mangled switch must not misfire silently in either direction |

The builder API (`withSubscriptionPool`) is unchanged - already explicit opt-in in code. Docs updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)