### PR TITLE
Replace default arguments with a named Limit.default

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -66,11 +66,14 @@ the pool is configured as follows:
 sec.subscription-pool {
   enabled             = true      # required - the pool is off by default
   streams-per-channel = 100      # required - the pool stays off without it
-  limit               = bounded  # bounded | unbounded
-  max-channels        = 10       # used when limit = bounded
-  sanity-cap          = 10       # used when limit = unbounded
+  limit               = bounded  # bounded | unbounded; absent = bounded with 10 channels
+  max-channels        = 10       # required when limit = bounded
+  sanity-cap          = 10       # required when limit = unbounded
 }
 ```
+
+Naming a `limit` kind requires its size: `limit = bounded` without `max-channels` (or `unbounded` without
+`sanity-cap`) is rejected at startup. Leaving `limit` out entirely gives the documented default.
 
 The pool is disabled by default: it only activates when both `enabled = true` and `streams-per-channel` are present.
 An absent `sec.subscription-pool` section means no pool. Setting `enabled = false` doubles as an operational

--- a/fs2/src/main/scala/sec/api/pool/policy.scala
+++ b/fs2/src/main/scala/sec/api/pool/policy.scala
@@ -25,10 +25,17 @@ import cats.syntax.all.*
 enum Limit:
 
   /** Grow to at most `max` channels, then fail fast with [[sec.api.exceptions.SubscriptionPoolExhausted]]. */
-  case Bounded(max: Int = 10)
+  case Bounded(max: Int)
 
   /** Grow forever; log at error level for every growth past `sanityCap`. */
-  case Unbounded(sanityCap: Int = 10)
+  case Unbounded(sanityCap: Int)
+
+object Limit:
+
+  /** Ten channels is an order of magnitude above a healthy subscription count for a single client at typical
+    * streams-per-channel values - a pool that wants to grow past it indicates a subscription leak, not load.
+    */
+  val default: Limit = Bounded(max = 10)
 
 /** Configuration for the subscription channel pool. */
 sealed abstract case class PoolConfig(streamsPerChannel: Int, limit: Limit)
@@ -41,9 +48,9 @@ object PoolConfig:
     *   silent default could quietly disagree with the server - which is the class of failure the pool exists to
     *   eliminate.
     * @param limit
-    *   growth limit, see [[Limit]]. Its `max` / `sanityCap` must be greater than or equal to 1.
+    *   growth limit, see [[Limit]] and [[Limit.default]]. Its `max` / `sanityCap` must be greater than or equal to 1.
     */
-  def apply(streamsPerChannel: Int, limit: Limit = Limit.Bounded()): Either[InvalidInput, PoolConfig] =
+  def apply(streamsPerChannel: Int, limit: Limit): Either[InvalidInput, PoolConfig] =
 
     val guardLimit: Either[InvalidInput, Limit] = limit match
       case Limit.Bounded(max) if max < 1 =>
@@ -56,7 +63,7 @@ object PoolConfig:
     else guardLimit.map(new PoolConfig(streamsPerChannel, _) {})
 
   /** As [[apply]], with the validation error lifted into `F`. */
-  def of[F[_]: ApplicativeThrow](streamsPerChannel: Int, limit: Limit = Limit.Bounded()): F[PoolConfig] =
+  def of[F[_]: ApplicativeThrow](streamsPerChannel: Int, limit: Limit): F[PoolConfig] =
     apply(streamsPerChannel, limit).liftTo[F]
 
 private[sec] case class SlotView(index: Int, free: Int, healthy: Boolean)

--- a/tests/src/test/scala/sec/api/pool/policy.scala
+++ b/tests/src/test/scala/sec/api/pool/policy.scala
@@ -24,8 +24,8 @@ import org.scalacheck.Prop.forAll
 class PoolPolicySuite extends SecScalaCheckSuite:
 
   test("PoolConfig rejects non-positive streams-per-channel and limits") {
-    assert(PoolConfig(0).isLeft)
-    assert(PoolConfig(-1).isLeft)
+    assert(PoolConfig(0, Limit.default).isLeft)
+    assert(PoolConfig(-1, Limit.default).isLeft)
     assert(PoolConfig(1, Limit.Bounded(0)).isLeft)
     assert(PoolConfig(1, Limit.Unbounded(0)).isLeft)
     assert(PoolConfig(1, Limit.Bounded(1)).isRight)

--- a/tests/src/test/scala/sec/tsc/config.scala
+++ b/tests/src/test/scala/sec/tsc/config.scala
@@ -383,8 +383,7 @@ class ConfigSuite extends SecSuite:
       val cfg = ConfigFactory.parseString(
         """
           | sec.subscription-pool {
-          |   enabled      = true
-          |   max-channels = 5
+          |   enabled = true
           | }
           |""".stripMargin
       )
@@ -404,7 +403,7 @@ class ConfigSuite extends SecSuite:
           |""".stripMargin
       )
 
-      assertEquals(mkPoolConfig[ErrorOr](cfg1), PoolConfig(100, Limit.Bounded()).map(_.some))
+      assertEquals(mkPoolConfig[ErrorOr](cfg1), PoolConfig(100, Limit.default).map(_.some))
 
       val cfg2 = ConfigFactory.parseString(
         """
@@ -422,18 +421,6 @@ class ConfigSuite extends SecSuite:
     }
 
     test("config - unbounded") {
-
-      val cfg1 = ConfigFactory.parseString(
-        """
-          | sec.subscription-pool {
-          |   enabled             = true
-          |   streams-per-channel = 100
-          |   limit               = unbounded
-          | }
-          |""".stripMargin
-      )
-
-      assertEquals(mkPoolConfig[ErrorOr](cfg1), PoolConfig(100, Limit.Unbounded()).map(_.some))
 
       val cfg2 = ConfigFactory.parseString(
         """
@@ -456,7 +443,6 @@ class ConfigSuite extends SecSuite:
         """
           | sec.subscription-pool {
           |   streams-per-channel = 100
-          |   max-channels        = 5
           | }
           |""".stripMargin
       )
@@ -466,7 +452,6 @@ class ConfigSuite extends SecSuite:
           | sec.subscription-pool {
           |   enabled             = false
           |   streams-per-channel = 100
-          |   max-channels        = 5
           | }
           |""".stripMargin
       )
@@ -486,11 +471,21 @@ class ConfigSuite extends SecSuite:
       assert(mkPoolConfig[ErrorOr](poolCfg("enabled = ture, streams-per-channel = 100")).isLeft)
       // a limit typo must not silently fall back to bounded
       assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, limit = unbouned")).isLeft)
+      // naming a limit kind without its size is half a config
+      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, limit = bounded")).isLeft)
+      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, limit = unbounded")).isLeft)
       // non-numeric values raise
       assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = many")).isLeft)
       // PoolConfig validation surfaces through the parser
       assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 0")).isLeft)
-      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, max-channels = 0")).isLeft)
+      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, limit = bounded, max-channels = 0")).isLeft)
+      // a size key without its kind - or with the wrong kind - would otherwise be silently ignored
+      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, max-channels = 5")).isLeft)
+      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, sanity-cap = 5")).isLeft)
+      assert(mkPoolConfig[ErrorOr](poolCfg("streams-per-channel = 100, limit = bounded, sanity-cap = 5")).isLeft)
+      assert(
+        mkPoolConfig[ErrorOr](
+          poolCfg("streams-per-channel = 100, limit = unbounded, max-channels = 5, sanity-cap = 5")).isLeft)
 
     }
 
@@ -506,6 +501,7 @@ class ConfigSuite extends SecSuite:
         | sec.subscription-pool {
         |   enabled             = true
         |   streams-per-channel = 100
+        |   limit               = bounded
         |   max-channels        = 5
         | }
         |""".stripMargin

--- a/tsc/src/main/scala/sec/tsc/package.scala
+++ b/tsc/src/main/scala/sec/tsc/package.scala
@@ -217,14 +217,27 @@ private[sec] object config:
 
     val result: Either[Throwable, Option[PoolConfig]] = for
       enabled <- cfg.strictOption(s"$spPath.enabled", _.getBoolean).map(_.getOrElse(false))
-      kind    <- cfg.strictOption(s"$spPath.limit", _.getString).map(_.map(_.trim.toLowerCase).getOrElse("bounded"))
-      limit   <- kind match
-                 case "bounded" =>
-                   cfg.strictOption(s"$spPath.max-channels", _.getInt).map(_.fold(Limit.Bounded())(Limit.Bounded(_)))
-                 case "unbounded" =>
-                   cfg.strictOption(s"$spPath.sanity-cap", _.getInt).map(_.fold(Limit.Unbounded())(Limit.Unbounded(_)))
-                 case other =>
+      kind    <- cfg.strictOption(s"$spPath.limit", _.getString).map(_.map(_.trim.toLowerCase))
+      max     <- cfg.strictOption(s"$spPath.max-channels", _.getInt)
+      cap     <- cfg.strictOption(s"$spPath.sanity-cap", _.getInt)
+      // An absent limit means the documented default; an explicit limit kind must be specified
+      // fully, and a size key must belong to the named kind. Anything else is half a config
+      // in which some written value would be silently ignored.
+      limit <- (kind, max, cap) match
+                 case (None, None, None)                 => Limit.default.asRight
+                 case (Some("bounded"), Some(m), None)   => Limit.Bounded(m).asRight
+                 case (Some("unbounded"), None, Some(c)) => Limit.Unbounded(c).asRight
+                 case (Some("bounded"), None, None)      =>
+                   InvalidInput(s"$spPath.limit = bounded requires $spPath.max-channels.").asLeft
+                 case (Some("unbounded"), None, None) =>
+                   InvalidInput(s"$spPath.limit = unbounded requires $spPath.sanity-cap.").asLeft
+                 case (Some(k @ ("bounded" | "unbounded")), _, _) =>
+                   InvalidInput(
+                     s"$spPath.limit = $k only takes ${if k == "bounded" then "max-channels" else "sanity-cap"}.").asLeft
+                 case (Some(other), _, _) =>
                    InvalidInput(s"$spPath.limit must be bounded or unbounded, it was $other.").asLeft
+                 case (None, _, _) =>
+                   InvalidInput(s"$spPath.max-channels and sanity-cap require $spPath.limit to name the kind.").asLeft
       spc <- cfg.strictOption(s"$spPath.streams-per-channel", _.getInt)
       // Everything written in the section is validated even when the pool is not enabled -
       // a disabled-but-invalid section must fail at startup, not on the day the switch flips.


### PR DESCRIPTION
`Limit.Bounded`/`Limit.Unbounded` no longer carry default parameter values. The default lives in exactly one documented place, following the `Options.default` house pattern:

```scala
object Limit:
  val default: Limit = Bounded(max = 10)
```

`PoolConfig.apply`/`.of` take the limit explicitly, so choosing the default is visible at every call site.

Config parsing is symmetric-strict - no written key may be silently ineffective:

| `limit` | size keys | result |
|---|---|---|
| absent | none | `Limit.default` |
| `bounded` | `max-channels` | `Bounded(n)` |
| `unbounded` | `sanity-cap` | `Unbounded(n)` |
| kind without its size | | rejected at startup |
| size key without kind / wrong kind / both sizes | | rejected at startup |

Previously `limit = unbounded` without `sanity-cap` silently fell back to 10, and a stray `max-channels` was silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)