### PR TITLE
fix: harden subscription channel pool

### DIFF
--- a/fs2/src/main/scala/sec/api/pool/pool.scala
+++ b/fs2/src/main/scala/sec/api/pool/pool.scala
@@ -28,7 +28,9 @@ import cats.effect.std.{AtomicCell, Semaphore}
   */
 private[sec] trait Pool[F[_], A]:
 
-  /** Held for one call's lifetime; permit released on finalize, including error and cancellation. */
+  /** Held for one call's lifetime; permit released on finalize, including error and cancellation. Raises
+    * `IllegalStateException` on a closed pool - a lease after close means the pool's resource scope was escaped.
+    */
   def lease: Resource[F, A]
 
   /** Occupancy per slot, pull-based. */
@@ -38,9 +40,14 @@ private[sec] object Pool:
 
   private[pool] case class Entry[F[_], A](value: A, permits: Semaphore[F], close: F[Unit])
 
+  private[pool] enum State[F[_], A]:
+    case Open(entries: Vector[Entry[F, A]])
+    case Closed[F[_], A]() extends State[F, A]
+
   private[pool] enum Outcome[F[_], A]:
     case Acquired(entry: Entry[F, A], grown: Option[GrowEvent])
     case Rejected[F[_], A](size: Int) extends Outcome[F, A]
+    case Closed[F[_], A]() extends Outcome[F, A]
 
   /** The pool serializes placement and growth through a single lock (the [[AtomicCell]]), so nothing that runs while it
     * is held may block or perform I/O: `mk` must only construct lazily (e.g. build an undialed channel) and `healthy`
@@ -53,15 +60,24 @@ private[sec] object Pool:
     onGrow: GrowEvent => F[Unit]
   )(using F: Concurrent[F]): Resource[F, Pool[F, A]] =
     Resource
-      .make(AtomicCell[F].of(Vector.empty[Entry[F, A]]))(
-        // Closing the pool closes every slot. Closes run in parallel, as each one may block for
-        // a shutdown-await period, and are attempted so one failed close cannot strand the rest.
-        _.get.flatMap(_.parTraverse_(_.close.attempt))
-      )
+      .make(AtomicCell[F].of[State[F, A]](State.Open(Vector.empty))) { cell =>
+        // Closing is a state transition, not a snapshot read: the cell is swapped to Closed under
+        // the lock, so an acquire racing shutdown either commits first - and its slot is in the
+        // snapshot closed below - or observes the closed pool and fails loudly. A slot can never
+        // grow into the void after close. Closes run after the lock is released, in parallel, as
+        // each may block for a shutdown-await period, and are attempted so one failed close
+        // cannot strand the rest.
+        cell
+          .evalModify[Vector[Entry[F, A]]] {
+            case State.Open(entries) => (State.Closed[F, A](), entries).pure[F]
+            case c @ State.Closed()  => (c, Vector.empty).pure[F]
+          }
+          .flatMap(_.parTraverse_(_.close.attempt))
+      }
       .map(state => new Impl(state, mk, healthy, cfg, onGrow))
 
   private class Impl[F[_], A](
-    state: AtomicCell[F, Vector[Entry[F, A]]],
+    state: AtomicCell[F, State[F, A]],
     mk: Resource[F, A],
     healthy: A => F[Boolean],
     cfg: PoolConfig,
@@ -70,33 +86,51 @@ private[sec] object Pool:
     extends Pool[F, A]:
 
     def stats: F[Vector[Int]] =
-      state.get.flatMap(_.traverse(_.permits.available.map(free => cfg.streamsPerChannel - free.toInt)))
+      state.get.flatMap {
+        case State.Open(entries) =>
+          entries.traverse(_.permits.available.map(free => cfg.streamsPerChannel - free.toInt))
+        case State.Closed() =>
+          Vector.empty[Int].pure[F]
+      }
 
+    // The acquire is masked end-to-end. AtomicCell.evalModify runs its body cancelably (only the
+    // mutex release is guaranteed) and Resource.make polls its acquire, so an unmasked acquire has
+    // windows where cancellation lands after a permit is taken - or a slot is built - but before
+    // the entry is committed and the release finalizer is registered, silently leaking capacity.
+    // The runtime observes cancellation between any two unmasked stages (every
+    // cancelationCheckThreshold run-loop iterations), so the windows are narrow but real.
+    // Masking is safe because everything under the cell's lock is non-blocking by the invariant
+    // documented on [[of]]; the cost is that a canceler waits out a short, bounded acquire.
     def lease: Resource[F, A] =
-      Resource.make(acquireEntry)(_.permits.release).map(_.value)
+      Resource.make(F.uncancelable(_ => acquireEntry))(_.permits.release).map(_.value)
 
-    // Everything inside evalModify runs while holding the cell's lock: only non-blocking
-    // permit tryAcquire, pure policy and lazy construction happen there. The decision is
-    // returned as a value; logging and error raising happen after the lock is released.
+    // Runs fully masked, see lease. Everything inside evalModify runs while holding the cell's
+    // lock: only non-blocking permit tryAcquire, pure policy and lazy construction happen there.
+    // The decision is returned as a value; logging and error raising happen after the lock is
+    // released - still inside the mask, so an acquired entry always reaches Resource.make.
     private def acquireEntry: F[Entry[F, A]] =
       state
-        .evalModify { entries =>
-          views(entries).flatMap { vs =>
-            val placed = PoolPolicy.placementOrder(vs).findM(i => entries(i).permits.tryAcquire).map(_.map(entries))
-            placed.flatMap {
-              case Some(e) => (entries, Outcome.Acquired(e, grown = None)).pure[F]
-              case None    =>
-                PoolPolicy.onSaturated(vs, cfg.streamsPerChannel, cfg.limit) match
-                  case Saturated.Reject(n) =>
-                    (entries, Outcome.Rejected[F, A](n)).pure[F]
-                  case Saturated.Grow(event) =>
-                    mkEntry.map(e => (entries :+ e, Outcome.Acquired(e, event.some)))
+        .evalModify[Outcome[F, A]] {
+          case c @ State.Closed()  => (c, Outcome.Closed[F, A]()).pure[F]
+          case State.Open(entries) =>
+            views(entries).flatMap { vs =>
+              val placed = PoolPolicy.placementOrder(vs).findM(i => entries(i).permits.tryAcquire).map(_.map(entries))
+              placed.flatMap {
+                case Some(e) => (State.Open(entries), Outcome.Acquired(e, grown = None)).pure[F]
+                case None    =>
+                  PoolPolicy.onSaturated(vs, cfg.streamsPerChannel, cfg.limit) match
+                    case Saturated.Reject(n) =>
+                      (State.Open(entries), Outcome.Rejected[F, A](n)).pure[F]
+                    case Saturated.Grow(event) =>
+                      mkEntry.map(e => (State.Open(entries :+ e), Outcome.Acquired(e, event.some)))
+              }
             }
-          }
         }
         .flatMap {
           case Outcome.Acquired(e, grown) => grown.traverse_(onGrow).as(e)
           case Outcome.Rejected(n)        => exceptions.SubscriptionPoolExhausted(n).raiseError
+          case Outcome.Closed()           =>
+            new IllegalStateException("Pool is closed - lease attempted after its resource was finalized.").raiseError
         }
 
     private def views(entries: Vector[Entry[F, A]]): F[Vector[SlotView]] =
@@ -106,14 +140,13 @@ private[sec] object Pool:
 
     // The only blocking `.acquire` in the pool, and it never actually waits: the semaphore is
     // freshly created with all permits available. Everything else uses non-blocking tryAcquire,
-    // which is what makes holding the cell's lock around this code safe. uncancelable spans
-    // construction-then-registration so a cancelled caller cannot leave behind a slot that was
-    // built but never recorded (and would then never be closed).
+    // which is what makes holding the cell's lock around this code safe. Runs inside the acquire
+    // mask (see lease); the mask must reach past the AtomicCell commit for construction to be
+    // safe, so it lives on lease rather than here - a slot built here is either committed and
+    // closable, or never built.
     private def mkEntry: F[Entry[F, A]] =
-      F.uncancelable { _ =>
-        for
-          ac  <- mk.allocated
-          sem <- Semaphore[F](cfg.streamsPerChannel.toLong)
-          _   <- sem.acquire
-        yield Entry(ac._1, sem, ac._2)
-      }
+      for
+        ac  <- mk.allocated
+        sem <- Semaphore[F](cfg.streamsPerChannel.toLong)
+        _   <- sem.acquire
+      yield Entry(ac._1, sem, ac._2)

--- a/tests/src/test/scala/sec/api/pool/pool.scala
+++ b/tests/src/test/scala/sec/api/pool/pool.scala
@@ -23,11 +23,19 @@ import cats.syntax.all.*
 import cats.effect.{IO, Ref, Resource}
 import cats.effect.std.Random
 import cats.effect.testkit.TestControl
+import cats.effect.unsafe.IORuntimeConfig
 
 /** Each test maps to an invariant of [[Pool]]. Do not weaken tests to pass; fix the pool instead.
   * TestControl.executeEmbed doubles as a deadlock detector: non-terminating programs fail, not hang.
   */
 class PoolSuite extends SecEffectSuite:
+
+  /** Cancellation observed at every unmasked run-loop iteration, preemption every other. The default
+    * threshold (512) makes the gap between a permit being taken and the entry being committed
+    * practically unobservable under TestControl while remaining real in production - under this
+    * config an unmasked acquire deterministically loses a pending-cancelled slot before commit.
+    */
+  val aggressiveRt: IORuntimeConfig = IORuntimeConfig(cancelationCheckThreshold = 1, autoYieldThreshold = 2)
 
   def poolConfig(streamsPerChannel: Int, limit: Limit): PoolConfig =
     PoolConfig(streamsPerChannel, limit).fold(e => fail(e.getMessage), identity)
@@ -78,7 +86,7 @@ class PoolSuite extends SecEffectSuite:
   }
 
   test("conservation under chaos: random hold/failure/cancellation leaks nothing") {
-    TestControl.executeEmbed {
+    TestControl.executeEmbed(
       (probe, Random.scalaUtilRandom[IO]).flatMapN { (p, rnd) =>
         testPool(p, poolConfig(4, Limit.Unbounded(3))).use { pool =>
           val op: IO[Unit] =
@@ -96,34 +104,42 @@ class PoolSuite extends SecEffectSuite:
             IO.sleep(1.second) *>
             pool.stats.flatMap(s => IO(assert(s.forall(_ == 0), s"leaked permits: $s")))
         }
-      }
-    }
+      },
+      aggressiveRt
+    )
   }
 
   test("cancellation racing acquire itself leaks nothing") {
-    TestControl.executeEmbed {
+    TestControl.executeEmbed(
       probe.flatMap { p =>
+        // With preemption every other iteration the cancel is signaled while the fiber is
+        // mid-acquire, exercising the gap between a successful tryAcquire and the commit.
         testPool(p, poolConfig(2, Limit.Unbounded(10))).use { pool =>
           pool.lease.use_.start.flatMap(_.cancel).replicateA_(100) *>
             pool.stats.flatMap(s => IO(assert(s.forall(_ == 0), s"leaked: $s")))
-        }
-      }
-    }
+        } *> (p.created.get, p.closed.get).flatMapN((c, cl) => IO(assertEquals(c, cl)))
+      },
+      aggressiveRt
+    )
   }
 
   test("cancellation during growth leaks neither permits nor channels") {
-    TestControl.executeEmbed {
+    TestControl.executeEmbed(
       probe.flatMap { p =>
-        // mkDelay widens the growth window so the cancel lands while construction
-        // is in flight (test injection only - real mk must not do I/O).
+        // mkDelay widens the growth window so the cancel is pending while construction is in
+        // flight (test injection only - real mk must not do I/O). Under aggressiveRt the pending
+        // cancel is observed at the first unmasked stage after construction - on an unmasked
+        // acquire that is deterministically after the slot is built but before it is committed,
+        // losing the slot - so this test is red unless the acquire is masked end-to-end.
         testPool(p, poolConfig(2, Limit.Bounded(5)), mkDelay = 5.millis).use { pool =>
           pool.lease.use_.start
             .flatMap(f => IO.sleep(1.milli) *> f.cancel)
             .replicateA_(10) *>
             pool.stats.flatMap(s => IO(assert(s.forall(_ == 0), s"leaked permits: $s")))
         } *> (p.created.get, p.closed.get).flatMapN((c, cl) => IO(assertEquals(c, cl)))
-      }
-    }
+      },
+      aggressiveRt
+    )
   }
 
   test("reconnect storm never grows the pool") {
@@ -164,4 +180,35 @@ class PoolSuite extends SecEffectSuite:
         }
       }
     }
+  }
+
+  test("close is a state transition: a late lease fails loudly instead of growing into the void") {
+    TestControl.executeEmbed(
+      probe.flatMap { p =>
+        testPool(p, poolConfig(2, Limit.Bounded(5))).allocated.flatMap { case (pool, close) =>
+          pool.lease.use_ *> close *>
+            pool.lease.use_.attempt.flatMap {
+              case Left(_: IllegalStateException) => IO.unit
+              case other                          => IO(fail(s"expected IllegalStateException, got $other"))
+            } *> (p.created.get, p.closed.get).flatMapN((c, cl) => IO(assertEquals(c, cl)))
+        }
+      },
+      aggressiveRt
+    )
+  }
+
+  test("close racing an in-flight acquire: the slot is either committed and closed, or never built") {
+    TestControl.executeEmbed(
+      probe.flatMap { p =>
+        // The acquire is mid-construction (mkDelay) when close begins. Close must serialize with
+        // it through the cell's lock: the committed slot lands in close's snapshot and is closed.
+        // A snapshot read taken before the commit would miss the slot and leak the channel.
+        testPool(p, poolConfig(2, Limit.Bounded(5)), mkDelay = 5.millis).allocated.flatMap { case (pool, close) =>
+          pool.lease.use(_ => IO.sleep(10.millis)).start.flatMap { f =>
+            IO.sleep(1.milli) *> close *> f.join.void
+          } *> (p.created.get, p.closed.get).flatMapN((c, cl) => IO(assertEquals(c, cl)))
+        }
+      },
+      aggressiveRt
+    )
   }


### PR DESCRIPTION
Mask lease acquisition end-to-end: AtomicCell.evalModify runs its body cancelably and Resource.make polls its acquire, leaving windows where cancellation leaks a permit or an unregistered slot. Make pool close a state transition (State.Open/Closed) so an acquire racing shutdown either commits into the closing snapshot or fails loudly, instead of growing a channel that is never closed. Strengthen cancellation tests with cancelationCheckThreshold=1 so the windows are deterministically observable.