### PR TITLE
Fit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ jobs:
           ./cluster.sh down
           popd
 
+      - name: Fault injection tests
+        timeout-minutes: 10
+        run: sbt '++ ${{ matrix.scala }}' 'tests / Fit / test'
+
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         run: mkdir -p fs2-netty/target fs2/target tsc/target core/target project/target

--- a/build.sbt
+++ b/build.sbt
@@ -82,20 +82,22 @@ lazy val tsc = project
 
 lazy val SingleNodeITest = config("sit") extend Test
 lazy val ClusterITest    = config("cit") extend Test
+lazy val FaultITest      = config("fit") extend Test
 
 lazy val tests = project
   .in(file("tests"))
   .enablePlugins(BuildInfoPlugin, AutomateHeaderPlugin, NoPublishPlugin)
-  .configs(SingleNodeITest, ClusterITest)
+  .configs(SingleNodeITest, ClusterITest, FaultITest)
   .settings(commonSettings)
   .settings(inConfig(SingleNodeITest)(Defaults.testSettings))
   .settings(inConfig(ClusterITest)(Defaults.testSettings))
+  .settings(inConfig(FaultITest)(Defaults.testSettings))
   .settings(
     logBuffered := false,
     parallelExecution := true,
     buildInfoPackage := "sec",
     buildInfoKeys := Seq(BuildInfoKey("certsPath" -> file("").getAbsoluteFile.toPath / "certs")),
-    Test / headerSources ++= (SingleNodeITest / sources).value ++ (ClusterITest / sources).value,
+    Test / headerSources ++= (SingleNodeITest / sources).value ++ (ClusterITest / sources).value ++ (FaultITest / sources).value,
     libraryDependencies :=
       compileM(
         fs2Io,
@@ -107,7 +109,8 @@ lazy val tests = project
         catsEffectTestkit,
         log4catsSlf4j,
         log4catsTesting,
-        logback
+        logback,
+        testcontainers
       )
   )
   .dependsOn(core, `fs2-netty`)
@@ -163,7 +166,7 @@ inThisBuild(
 
 //==== Github Actions ==================================================================================================
 
-addCommandAlias("compileTests", "tests / Test / compile; tests / Sit / compile; tests / Cit / compile;")
+addCommandAlias("compileTests", "tests / Test / compile; tests / Sit / compile; tests / Cit / compile; tests / Fit / compile;")
 addCommandAlias("compileDocs", "docs/mdoc")
 
 inThisBuild(
@@ -230,6 +233,11 @@ inThisBuild(
         name     = Some("Stop Cluster Nodes"),
         commands = List("pushd .docker", "./cluster.sh down", "popd"),
         cond     = Some(s"always()")
+      ),
+      WorkflowStep.Sbt(
+        commands       = List("tests / Fit / test"),
+        name           = Some("Fault injection tests"),
+        timeoutMinutes = Some(10)
       )
     ),
     githubWorkflowPublish ++= Seq(

--- a/fs2/src/main/scala/sec/api/pool/pool.scala
+++ b/fs2/src/main/scala/sec/api/pool/pool.scala
@@ -93,22 +93,21 @@ private[sec] object Pool:
           Vector.empty[Int].pure[F]
       }
 
-    // The acquire is masked end-to-end. AtomicCell.evalModify runs its body cancelably (only the
-    // mutex release is guaranteed) and Resource.make polls its acquire, so an unmasked acquire has
-    // windows where cancellation lands after a permit is taken - or a slot is built - but before
-    // the entry is committed and the release finalizer is registered, silently leaking capacity.
-    // The runtime observes cancellation between any two unmasked stages (every
-    // cancelationCheckThreshold run-loop iterations), so the windows are narrow but real.
-    // Masking is safe because everything under the cell's lock is non-blocking by the invariant
-    // documented on [[of]]; the cost is that a canceler waits out a short, bounded acquire.
+    // Resource.make runs its acquire uncancelably; unlike makeFull, its
+    // allocator ignores Poll. Thus acquireEntry remains masked through the
+    // AtomicCell commit and until the permit-release finalizer is installed.
+    // The growth callback deliberately runs afterwards: if it fails or is
+    // canceled, the permit acquired below is released.
     def lease: Resource[F, A] =
-      Resource.make(F.uncancelable(_ => acquireEntry))(_.permits.release).map(_.value)
+      Resource
+        .make(acquireEntry) { case (entry, _) => entry.permits.release }
+        .evalTap { case (_, grown) => grown.traverse_(onGrow) }
+        .map { case (entry, _) => entry.value }
 
-    // Runs fully masked, see lease. Everything inside evalModify runs while holding the cell's
-    // lock: only non-blocking permit tryAcquire, pure policy and lazy construction happen there.
-    // The decision is returned as a value; logging and error raising happen after the lock is
-    // released - still inside the mask, so an acquired entry always reaches Resource.make.
-    private def acquireEntry: F[Entry[F, A]] =
+    // Everything inside evalModify runs while holding the cell's lock: only non-blocking permit tryAcquire,
+    // pure policy and lazy construction happen there. The decision is returned as a value; callbacks and
+    // error raising happen after the lock is released.
+    private def acquireEntry: F[(Entry[F, A], Option[GrowEvent])] =
       state
         .evalModify[Outcome[F, A]] {
           case c @ State.Closed()  => (c, Outcome.Closed[F, A]()).pure[F]
@@ -127,7 +126,7 @@ private[sec] object Pool:
             }
         }
         .flatMap {
-          case Outcome.Acquired(e, grown) => grown.traverse_(onGrow).as(e)
+          case Outcome.Acquired(e, grown) => (e, grown).pure[F]
           case Outcome.Rejected(n)        => exceptions.SubscriptionPoolExhausted(n).raiseError
           case Outcome.Closed()           =>
             new IllegalStateException("Pool is closed - lease attempted after its resource was finalized.").raiseError
@@ -140,10 +139,8 @@ private[sec] object Pool:
 
     // The only blocking `.acquire` in the pool, and it never actually waits: the semaphore is
     // freshly created with all permits available. Everything else uses non-blocking tryAcquire,
-    // which is what makes holding the cell's lock around this code safe. Runs inside the acquire
-    // mask (see lease); the mask must reach past the AtomicCell commit for construction to be
-    // safe, so it lives on lease rather than here - a slot built here is either committed and
-    // closable, or never built.
+    // which is what makes holding the cell's lock around this code safe. Resource.make keeps this
+    // acquisition masked until the entry is committed and its permit-release finalizer is registered.
     private def mkEntry: F[Entry[F, A]] =
       for
         ac  <- mk.allocated

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
     val munitDiscipline = "2.0.0"
     val munitEffect     = "2.2.0"
     val munit           = "1.3.4"
+    val testcontainers  = "2.0.5"
 
   }
 
@@ -58,6 +59,7 @@ object Dependencies {
   val logback         = "ch.qos.logback" % "logback-classic"  % versions.logback
   val log4catsTesting = "org.typelevel" %% "log4cats-testing" % versions.log4cats
   val log4catsSlf4j   = "org.typelevel" %% "log4cats-slf4j"   % versions.log4cats
+  val testcontainers  = "org.testcontainers" % "testcontainers" % versions.testcontainers
 
   // Misc
 

--- a/tests/src/fit/scala/sec/api/fsuite.scala
+++ b/tests/src/fit/scala/sec/api/fsuite.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import java.net.{HttpURLConnection, URI}
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.*
+import scala.util.Try
+import cats.data.NonEmptyList
+import cats.effect.{IO, Resource}
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import sec.arbitraries.*
+
+/** A single KurrentDB node under test-controlled fault injection. Insecure and disk-backed on purpose: TLS is
+  * irrelevant to the transport behavior under test, and [[KdbNode.restart]] must preserve stream state - a mem-db
+  * reset would legitimately stall subscribers holding positions.
+  */
+final class KdbNode private (container: KdbNode.Kdb):
+
+  def endpoint: Endpoint = Endpoint(container.getHost, container.getMappedPort(KdbNode.grpcPort))
+
+  /** Restarts the node in-place via the docker daemon - same container, same filesystem layer, same port mapping -
+    * and awaits readiness. Every live gRPC connection receives a real GOAWAY / connection loss: the fault the
+    * subscription pool must absorb by re-placing onto freed permits instead of growing or stalling.
+    */
+  def restart: IO[Unit] =
+    IO.blocking(container.getDockerClient.restartContainerCmd(container.getContainerId).exec()).void *>
+      IO.defer(awaitReady)
+
+  private def awaitReady: IO[Unit] =
+    val url     = s"http://${container.getHost}:${container.getMappedPort(KdbNode.grpcPort)}/health/live"
+    val timeout = 30.seconds
+    val probe = IO.blocking {
+      val conn = URI.create(url).toURL.openConnection().asInstanceOf[HttpURLConnection]
+      conn.setConnectTimeout(1000)
+      conn.setReadTimeout(1000)
+      try conn.getResponseCode
+      finally conn.disconnect()
+    }
+
+    IO.monotonic.flatMap { started =>
+      def loop: IO[Unit] =
+        probe.attempt.flatMap {
+          case Right(status) if status >= 200 && status < 300 => IO.unit
+          case last                                           =>
+            IO.monotonic.flatMap { now =>
+              if now - started >= timeout then
+                readinessFailure(url, timeout, last).flatMap(error => IO.raiseError[Unit](error))
+              else IO.sleep(250.millis) *> loop
+            }
+        }
+
+      loop
+    }
+
+  private def readinessFailure(
+    url: String,
+    timeout: FiniteDuration,
+    last: Either[Throwable, Int]
+  ): IO[TimeoutException] =
+    IO.blocking {
+      val probeDetail = last.fold(
+        error => s"${error.getClass.getName}: ${Option(error.getMessage).getOrElse("<no message>")}",
+        status => s"HTTP $status"
+      )
+      val running = Try(container.isRunning).fold(
+        error => s"unknown (${Option(error.getMessage).getOrElse("<no message>")})",
+        _.toString
+      )
+      val logs = Try(Option(container.getLogs).getOrElse("")).fold(
+        error => s"<unavailable: ${Option(error.getMessage).getOrElse("<no message>")}>",
+        identity
+      )
+      new TimeoutException(
+        s"KurrentDB did not become ready within $timeout. url=$url, lastProbe=$probeDetail, " +
+          s"containerRunning=$running\n--- container logs (last 8000 chars) ---\n${logs.takeRight(8000)}"
+      )
+    }
+
+object KdbNode:
+
+  final private val grpcPort = 2113
+  final private val image    = sys.env.getOrElse("KDB_IMAGE", "docker.io/kurrentplatform/kurrentdb:26.1")
+
+  private[api] val maxStreams: Int =
+    sys.env.get("SEC_FIT_MAX_STREAMS").fold(8) { raw =>
+      raw.toIntOption.filter(_ >= 3).getOrElse {
+        throw new IllegalArgumentException(s"SEC_FIT_MAX_STREAMS must be an integer >= 3, but was '$raw'.")
+      }
+    }
+
+  final private class Kdb(img: DockerImageName, hostPort: Int) extends GenericContainer[Kdb](img):
+    addFixedExposedPort(hostPort, grpcPort)
+
+  val resource: Resource[IO, KdbNode] = Resource
+    .make(IO.blocking {
+      val socket = new java.net.ServerSocket(0)
+      val hostPort =
+        try socket.getLocalPort
+        finally socket.close()
+      val c = new Kdb(DockerImageName.parse(image), hostPort)
+      c.withEnv("KURRENTDB_INSECURE", "true")
+      c.withEnv("KURRENTDB_MEM_DB", "false")
+      c.withEnv("Kestrel__Limits__Http2__MaxStreamsPerConnection", maxStreams.toString)
+      c.setWaitStrategy(Wait.forHttp("/health/live").forPort(grpcPort).forStatusCode(204))
+      c.start()
+      c
+    })(c => IO.blocking(c.stop()))
+    .map(new KdbNode(_))
+
+trait FSuite extends SecResourceSuite[KdbNode]:
+
+  override def munitIOTimeout: Duration = 10.minutes
+
+  def makeResource: Resource[IO, KdbNode] = KdbNode.resource
+
+  final def node: KdbNode = resource
+
+  /** Insecure single-node client against the container's mapped port. No gossip-based rerouting is involved for a
+    * single node, so a random mapped port needs no advertise configuration on the server.
+    */
+  final def mkClient(mod: SingleNodeBuilder[IO] => SingleNodeBuilder[IO] = identity): Resource[IO, EsClient[IO]] =
+    mod(
+      EsClient
+        .singleNode[IO](node.endpoint)
+        .withChannelShutdownAwait(200.millis)
+        .withLogger(log)
+    ).resource
+
+  final def genStreamId(streamPrefix: String): StreamId.Id = sampleOfGen(idGen.genStreamIdNormal(streamPrefix))
+
+  final def genEvents(n: Int): NonEmptyList[EventData] =
+    sampleOfGen(eventdataGen.eventDataNelN(n, eventTypeGen.defaultPrefix))

--- a/tests/src/fit/scala/sec/api/streams/poolFaults.scala
+++ b/tests/src/fit/scala/sec/api/streams/poolFaults.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import scala.concurrent.duration.*
+import cats.effect.{Deferred, IO, Resource}
+import cats.effect.std.Supervisor
+import cats.syntax.all.*
+import sec.syntax.all.*
+import sec.api.exceptions.ResubscriptionRequired
+import sec.api.pool.{Limit, PoolConfig}
+
+/** Fault-injection coverage against a real node: the failure modes the pool exists for, which unit tests and a
+  * healthy integration node cannot provoke.
+  */
+class PoolFaultsSuite extends FSuite:
+
+  import StreamState.*
+
+  /** The value configured on the Kestrel server by [[KdbNode]]. */
+  final private val maxStreams  = KdbNode.maxStreams
+  final private val subscribers = maxStreams + 5
+
+  test("beyond MAX_CONCURRENT_STREAMS: unpooled subscriptions stall loudly, pooled all confirm") {
+
+    // The original production incident: grpc-java queues streams beyond the server's limit without
+    // surfacing anything. Client-side, the confirmation timeout converts the silent stall into
+    // ResubscriptionRequired; with retries disabled it surfaces here. The pool removes the stall.
+    val confirmIn = 3.seconds
+    val window    = confirmIn + 2.seconds
+
+    def outcomes(client: EsClient[IO], prefix: String): IO[List[Either[Throwable, Unit]]] =
+      (0 until subscribers).toList.parTraverse { i =>
+        client.streams
+          .subscribeToStream(genStreamId(s"${prefix}_${i}_"), None)
+          .interruptAfter(window)
+          .compile
+          .drain
+          .attempt
+      }
+
+    val unpooled =
+      mkClient(_.withOperationsRetryDisabled.withSubscriptionConfirmationTimeout(confirmIn))
+
+    val pooled = Resource
+      .eval(PoolConfig.of[IO](maxStreams, Limit.Bounded(3)))
+      .flatMap { pc =>
+        mkClient(_.withSubscriptionPool(pc).withOperationsRetryDisabled.withSubscriptionConfirmationTimeout(confirmIn))
+      }
+
+    for
+      u      <- unpooled.use(outcomes(_, "fit_msc_unpooled"))
+      stalled = u.count {
+                  case Left(_: ResubscriptionRequired) => true
+                  case _                               => false
+                }
+      other   = u.collect { case Left(t) if !t.isInstanceOf[ResubscriptionRequired] => t }
+      _      <- IO(assert(other.isEmpty, s"unexpected failures: $other"))
+      _      <- IO(assertEquals(
+                  stalled,
+                  subscribers - maxStreams,
+                  s"expected exactly ${subscribers - maxStreams} subscriptions stalled beyond the configured " +
+                    s"HTTP/2 stream limit of $maxStreams"
+                ))
+      p      <- pooled.use(outcomes(_, "fit_msc_pooled"))
+      _      <- IO(assert(p.forall(_.isRight), s"pooled subscriptions failed: ${p.collect { case Left(t) => t }}"))
+    yield ()
+  }
+
+  test("node restart: every pooled subscription resumes; a GOAWAY storm re-places instead of stalling") {
+
+    val pooled = Resource
+      .eval(PoolConfig.of[IO](2, Limit.Bounded(5)))
+      .flatMap { pc =>
+        mkClient(
+          _.withSubscriptionPool(pc)
+            .withOperationsRetryMaxAttempts(120)
+            .withOperationsRetryMaxDelay(250.millis)
+        )
+      }
+
+    pooled.use { client =>
+      val ids = (0 until 6).toList.map(i => genStreamId(s"fit_restart_${i}_"))
+
+      // Child fibers are finalized before pooled.use releases the client and its pool. If restart fails,
+      // no resubscription fiber can escape the resource scope and attempt a lease on a closed pool.
+      Supervisor[IO].use { supervisor =>
+        for
+          firstSeen <- ids.traverse(_ => Deferred[IO, Unit])
+          subs      <- ids.zip(firstSeen).parTraverse { case (id, seen) =>
+                         supervisor.supervise(
+                           client.streams
+                             .subscribeToStream(id, None)
+                             .evalTap(_ => seen.complete(()).void)
+                             .take(2)
+                             .compile
+                             .toList
+                         )
+                       }
+          first     <- ids.parTraverse(id => client.streams.appendToStream(id, NoStream, genEvents(1)))
+          _         <- firstSeen.parTraverse_(_.get).timeout(15.seconds)
+          _         <- node.restart
+          second    <- ids.parTraverse(id => client.streams.appendToStream(id, StreamState.Any, genEvents(1)))
+          recs      <- subs.parTraverse(_.joinWithNever).timeout(45.seconds)
+          expected  = first.zip(second).map { case (before, after) =>
+                         List(before.streamPosition, after.streamPosition)
+                       }
+          _         <- IO(assertEquals(recs.map(_.map(event => Event.streamPosition(event))), expected))
+        yield ()
+      }
+    }
+  }

--- a/tests/src/test/scala/sec/api/pool/pool.scala
+++ b/tests/src/test/scala/sec/api/pool/pool.scala
@@ -30,10 +30,8 @@ import cats.effect.unsafe.IORuntimeConfig
   */
 class PoolSuite extends SecEffectSuite:
 
-  /** Cancellation observed at every unmasked run-loop iteration, preemption every other. The default
-    * threshold (512) makes the gap between a permit being taken and the entry being committed
-    * practically unobservable under TestControl while remaining real in production - under this
-    * config an unmasked acquire deterministically loses a pending-cancelled slot before commit.
+  /** Cancellation observed at every unmasked run-loop iteration, with preemption every other iteration.
+    * This makes the cancellation invariant tests exercise far more interleavings under TestControl.
     */
   val aggressiveRt: IORuntimeConfig = IORuntimeConfig(cancelationCheckThreshold = 1, autoYieldThreshold = 2)
 
@@ -48,14 +46,20 @@ class PoolSuite extends SecEffectSuite:
   /** Slots are Ints; construction/closure counted; health via Ref; optional construction failure via Ref; optional
     * construction delay to widen the growth window for cancellation injection.
     */
-  def testPool(p: Probe, cfg: PoolConfig, failMk: Option[Ref[IO, Boolean]] = None, mkDelay: FiniteDuration = 0.millis) =
+  def testPool(
+    p: Probe,
+    cfg: PoolConfig,
+    failMk: Option[Ref[IO, Boolean]] = None,
+    mkDelay: FiniteDuration = 0.millis,
+    onGrow: GrowEvent => IO[Unit] = _ => IO.unit
+  ) =
     val mk = Resource.make(
       IO.sleep(mkDelay) *> failMk.fold(IO.pure(false))(_.get).flatMap { fail =>
         if fail then IO.raiseError(new RuntimeException("mk boom"))
         else p.created.updateAndGet(_ + 1)
       }
     )(_ => p.closed.update(_ + 1))
-    Pool.of[IO, Int](mk, id => p.down.get.map(!_.contains(id)), cfg, _ => IO.unit)
+    Pool.of[IO, Int](mk, id => p.down.get.map(!_.contains(id)), cfg, onGrow)
 
   test("growth is exactly ceil(k / streamsPerChannel); shutdown closes all") {
     TestControl.executeEmbed {
@@ -112,8 +116,7 @@ class PoolSuite extends SecEffectSuite:
   test("cancellation racing acquire itself leaks nothing") {
     TestControl.executeEmbed(
       probe.flatMap { p =>
-        // With preemption every other iteration the cancel is signaled while the fiber is
-        // mid-acquire, exercising the gap between a successful tryAcquire and the commit.
+        // With frequent preemption the cancel is often signaled while the fiber is mid-acquire.
         testPool(p, poolConfig(2, Limit.Unbounded(10))).use { pool =>
           pool.lease.use_.start.flatMap(_.cancel).replicateA_(100) *>
             pool.stats.flatMap(s => IO(assert(s.forall(_ == 0), s"leaked: $s")))
@@ -126,11 +129,8 @@ class PoolSuite extends SecEffectSuite:
   test("cancellation during growth leaks neither permits nor channels") {
     TestControl.executeEmbed(
       probe.flatMap { p =>
-        // mkDelay widens the growth window so the cancel is pending while construction is in
-        // flight (test injection only - real mk must not do I/O). Under aggressiveRt the pending
-        // cancel is observed at the first unmasked stage after construction - on an unmasked
-        // acquire that is deterministically after the slot is built but before it is committed,
-        // losing the slot - so this test is red unless the acquire is masked end-to-end.
+        // mkDelay widens the growth window so cancellation races slot construction
+        // (test injection only - real mk must not do I/O).
         testPool(p, poolConfig(2, Limit.Bounded(5)), mkDelay = 5.millis).use { pool =>
           pool.lease.use_.start
             .flatMap(f => IO.sleep(1.milli) *> f.cancel)
@@ -161,6 +161,31 @@ class PoolSuite extends SecEffectSuite:
             failing.set(false) *>
             pool.lease.use(_ => pool.stats.flatMap(s => IO(assertEquals(s.sum, 1))))
         }
+      }
+    }
+  }
+
+  test("onGrow failure releases the acquired permit") {
+    TestControl.executeEmbed {
+      (probe, IO.ref(true)).flatMapN { (p, failGrow) =>
+        val hook: GrowEvent => IO[Unit] = _ =>
+          failGrow.get.flatMap { fail =>
+            if fail then IO.raiseError(new RuntimeException("onGrow boom"))
+            else IO.unit
+          }
+
+        testPool(p, poolConfig(1, Limit.Bounded(1)), onGrow = hook).use { pool =>
+          for
+            failed       <- pool.lease.use_.attempt
+            _            <- IO(assert(failed.isLeft))
+            afterFailure <- pool.stats
+            _            <- IO(assertEquals(afterFailure, Vector(0)))
+            _            <- failGrow.set(false)
+            _            <- pool.lease.use_
+            afterSuccess <- pool.stats
+            _            <- IO(assertEquals(afterSuccess, Vector(0)))
+          yield ()
+        } *> (p.created.get, p.closed.get).flatMapN((created, closed) => IO(assertEquals(created, closed)))
       }
     }
   }


### PR DESCRIPTION
Adds a tests/Fit config backed by testcontainers: single insecure disk-backed node with in-place docker restart for real GOAWAY injection and a configurable Kestrel HTTP/2 stream limit. Covers the two faults the pool exists for: subscriptions beyond MAX_CONCURRENT_STREAMS stall loudly unpooled and all confirm pooled, and a node restart resumes every pooled subscription without growing the pool. Pool: run onGrow only after the lease finalizer is registered so a failing or canceled callback releases its permit; document why Resource.make needs no explicit mask.