### PR TITLE
feat: multi-stream append via the v2 protocol

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,11 @@ lazy val commonSettings = Seq(
   scalaVersion := Scala3,
   tlJdkRelease := Some(jdkRelease),
   scalacOptions ~= (_.filterNot(_ == "-Ykind-projector:underscores")),
-  scalacOptions ++= Seq("-Wconf:msg=unused implicit parameter in extension method:s"),
+  scalacOptions ++= Seq(
+    "-Wconf:msg=unused implicit parameter in extension method:s",
+    // Generated sources (scalapb / fs2-grpc) are not ours to lint; CI runs with fatal warnings.
+    "-Wconf:src=src_managed/.*:s"
+  ),
   Compile / doc / scalacOptions ~= (_.filterNot(_ == "-Xfatal-warnings"))
 )
 

--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -103,3 +103,37 @@ object exceptions:
 
     final case class MaximumSubscribersReached(streamId: String, groupName: String)
       extends EsException(s"Maximum subscriptions reached for subscription group '$groupName' on stream '$streamId.'")
+
+  // Multi-stream append. Constructed from structured google.rpc.Status details of the v2
+  // protocol, see [[sec.api.grpc.convertV2]].
+
+  case class DuplicateStreams(streamIds: List[String])
+    extends EsException(s"Multi-stream append requires distinct streams; duplicates: ${streamIds.mkString(", ")}.")
+
+  case class StreamAlreadyExists(streamId: String)
+    extends EsException(s"Event stream '$streamId' already exists.")
+
+  case class StreamTombstoned(streamId: String)
+    extends EsException(s"Event stream '$streamId' is tombstoned.")
+
+  /** expected / actual use StreamState sentinel encoding: -1 NoStream, -2 Any, -4 StreamExists, >= 0 exact. */
+  case class StreamRevisionConflict(streamId: String, expected: Long, actual: Long)
+    extends EsException(s"Stream '$streamId' revision conflict: expected $expected, actual $actual.")
+
+  case class AppendRecordSizeExceeded(streamId: String, recordId: String, size: Int, maxSize: Int)
+    extends EsException(s"Record '$recordId' for stream '$streamId' is $size bytes, exceeding max of $maxSize.")
+
+  case class AppendTransactionSizeExceeded(size: Int, maxSize: Int)
+    extends EsException(s"Append transaction is $size bytes, exceeding max of $maxSize.")
+
+  case class AppendConsistencyViolation(violations: List[AppendConsistencyViolation.StreamStateViolation])
+    extends EsException(AppendConsistencyViolation.mkMsg(violations))
+
+  object AppendConsistencyViolation:
+
+    /** expected / actual use StreamState sentinel encoding: -1 NoStream, -2 Any, -4 StreamExists, >= 0 exact. */
+    case class StreamStateViolation(streamId: String, expected: Long, actual: Long)
+
+    private[sec] def mkMsg(vs: List[StreamStateViolation]): String =
+      val detail = vs.map(v => s"'${v.streamId}' expected ${v.expected}, actual ${v.actual}").mkString("; ")
+      s"Append failed due to consistency violations: $detail."

--- a/core/src/main/scala/sec/api/grpc/convertV2.scala
+++ b/core/src/main/scala/sec/api/grpc/convertV2.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+package grpc
+
+import cats.syntax.all.*
+import com.google.protobuf.any.Any as PbAny
+import com.google.rpc.Status as PbStatus
+import io.grpc.{Metadata, StatusRuntimeException}
+import io.kurrentdb.protocol.v2.streams.errors as v2e
+import sec.api.exceptions.*
+
+/** Converts v2 protocol errors to typed exceptions. Unlike v1, which uses bespoke string trailers,
+  * v2 carries structured details: a google.rpc.Status in the standard `grpc-status-details-bin`
+  * trailer, holding packed messages from `kurrentdb/protocol/v2/streams/errors.proto`.
+  */
+private[sec] object convertV2:
+
+  private val statusDetails: Metadata.Key[Array[Byte]] =
+    Metadata.Key.of("grpc-status-details-bin", Metadata.BINARY_BYTE_MARSHALLER)
+
+  /** None when no recognized structured details are present - callers fall back to status-code
+    * level handling.
+    */
+  val convertToEs: StatusRuntimeException => Option[EsException] = ex =>
+    for
+      md     <- Option(ex.getTrailers)
+      bytes  <- Option(md.get(statusDetails))
+      status <- Either.catchNonFatal(PbStatus.parseFrom(bytes)).toOption
+      es     <- status.details.toList.collectFirstSome(fromDetail)
+    yield es
+
+  private def unpackAs[A <: scalapb.GeneratedMessage: scalapb.GeneratedMessageCompanion](a: PbAny): Option[A] =
+    if a.is[A] then Either.catchNonFatal(a.unpack[A]).toOption else None
+
+  private def fromDetail(a: PbAny): Option[EsException] =
+    unpackAs[v2e.AppendConsistencyViolationErrorDetails](a).map { d =>
+      AppendConsistencyViolation(d.violations.toList.flatMap { cv =>
+        cv.`type`.streamState.map { ss =>
+          AppendConsistencyViolation.StreamStateViolation(ss.stream, ss.expectedState, ss.actualState)
+        }
+      })
+    } orElse
+      unpackAs[v2e.StreamRevisionConflictErrorDetails](a).map { d =>
+        StreamRevisionConflict(d.stream, d.expectedRevision, d.actualRevision)
+      } orElse
+      unpackAs[v2e.AppendRecordSizeExceededErrorDetails](a).map { d =>
+        AppendRecordSizeExceeded(d.stream, d.recordId, d.size, d.maxSize)
+      } orElse
+      unpackAs[v2e.AppendTransactionSizeExceededErrorDetails](a).map { d =>
+        AppendTransactionSizeExceeded(d.size, d.maxSize)
+      } orElse
+      unpackAs[v2e.StreamAlreadyExistsErrorDetails](a).map(d => StreamAlreadyExists(d.stream)) orElse
+      unpackAs[v2e.StreamTombstonedErrorDetails](a).map(d => StreamTombstoned(d.stream)) orElse
+      unpackAs[v2e.StreamDeletedErrorDetails](a).map(d => StreamDeleted(d.stream)) orElse
+      unpackAs[v2e.StreamNotFoundErrorDetails](a).map(d => StreamNotFound(d.stream))

--- a/core/src/main/scala/sec/api/mapping/streamsV2.scala
+++ b/core/src/main/scala/sec/api/mapping/streamsV2.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+package mapping
+
+import cats.MonadThrow
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import com.google.protobuf.struct as ps
+import io.kurrentdb.protocol.v2.streams as pv2
+
+private[sec] object streamsV2:
+
+  /** StreamState sentinel encoding used by v2 checks: -1 NoStream, -2 Any, -4 StreamExists,
+    * otherwise the exact revision.
+    */
+  def mkExpectedState(ss: StreamState): Long = ss match
+    case StreamState.NoStream     => -1L
+    case StreamState.Any          => -2L
+    case StreamState.StreamExists => -4L
+    case e: StreamPosition.Exact  => e.value.toLong
+
+  def mkSchemaFormat(f: SchemaFormat): pv2.SchemaFormat = f match
+    case SchemaFormat.Json     => pv2.SchemaFormat.SCHEMA_FORMAT_JSON
+    case SchemaFormat.Protobuf => pv2.SchemaFormat.SCHEMA_FORMAT_PROTOBUF
+    case SchemaFormat.Avro     => pv2.SchemaFormat.SCHEMA_FORMAT_AVRO
+    case SchemaFormat.Bytes    => pv2.SchemaFormat.SCHEMA_FORMAT_BYTES
+
+  def mkValue(p: PropertyValue): ps.Value = p match
+    case PropertyValue.Str(v)  => ps.Value(ps.Value.Kind.StringValue(v))
+    case PropertyValue.Num(v)  => ps.Value(ps.Value.Kind.NumberValue(v))
+    case PropertyValue.Bool(v) => ps.Value(ps.Value.Kind.BoolValue(v))
+
+  def mkAppendRecord(streamId: StreamId.Id, r: RecordData): pv2.AppendRecord =
+    pv2.AppendRecord(
+      recordId   = Some(r.recordId.toString),
+      properties = r.properties.toMap.view.mapValues(mkValue).toMap,
+      schema     = Some(pv2.SchemaInfo(format = mkSchemaFormat(r.schema.format), name = r.schema.name)),
+      data       = r.data.toByteString,
+      stream     = streamId.stringValue
+    )
+
+  def mkCheck(streamId: StreamId.Id, expected: StreamState): pv2.ConsistencyCheck =
+    pv2
+      .ConsistencyCheck()
+      .withStreamState(
+        pv2.ConsistencyCheck.StreamStateCheck(stream = streamId.stringValue, expectedState = mkExpectedState(expected))
+      )
+
+  /** Every written stream carries exactly one check; guards add checks for unwritten streams. */
+  def mkAppendRecordsRequest(appends: NonEmptyList[StreamAppend], guards: List[StreamGuard]): pv2.AppendRecordsRequest =
+    pv2.AppendRecordsRequest(
+      records = appends.toList.flatMap(a => a.records.toList.map(mkAppendRecord(a.streamId, _))),
+      checks  = appends.toList.map(a => mkCheck(a.streamId, a.expected)) ++
+        guards.map(g => mkCheck(g.streamId, g.expected))
+    )
+
+  /** Recovers typed stream ids by joining response revisions with the request's appends. */
+  def mkMultiAppendResult[F[_]: MonadThrow](
+    appends: NonEmptyList[StreamAppend]
+  )(resp: pv2.AppendRecordsResponse): F[MultiAppendResult] =
+    val byName = appends.toList.map(a => a.streamId.stringValue -> a.streamId).toMap
+    resp.revisions.toList
+      .traverse { r =>
+        byName
+          .get(r.stream)
+          .map(id => id -> StreamPosition(r.revision))
+          .fold(shared.mkError[(StreamId.Id, StreamPosition.Exact)](
+            s"Unexpected stream '${r.stream}' in AppendRecordsResponse"
+          ))(_.asRight)
+      }
+      .flatMap { rs =>
+        NonEmptyList.fromList(rs).fold(shared.mkError[NonEmptyList[(StreamId.Id, StreamPosition.Exact)]](
+          "AppendRecordsResponse contained no revisions"
+        ))(_.asRight)
+      }
+      .flatMap { rs =>
+        val missing = appends.toList.map(_.streamId.stringValue).toSet -- rs.toList.map(_._1.stringValue).toSet
+        if missing.isEmpty then rs.asRight
+        else shared.mkError[NonEmptyList[(StreamId.Id, StreamPosition.Exact)]](
+          s"AppendRecordsResponse missing revisions for: ${missing.mkString(", ")}"
+        )
+      }
+      .map(MultiAppendResult(LogPosition.exact(resp.position, resp.position), _))
+      .liftTo[F]

--- a/core/src/main/scala/sec/api/multiAppend.scala
+++ b/core/src/main/scala/sec/api/multiAppend.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import java.util.UUID
+import cats.data.NonEmptyList
+import scodec.bits.ByteVector
+
+/** A record for [[Streams.multiStreamAppend]]. Unlike [[EventData]] there are no raw metadata
+  * bytes: the server synthesizes the v1 metadata view as a JSON object of [[RecordData.properties]]
+  * merged with reserved `$`-prefixed schema keys, and [[Schema.name]] surfaces as the v1 eventType.
+  */
+case class RecordData(
+  recordId: UUID,
+  schema: Schema,
+  data: ByteVector,
+  properties: Properties
+)
+
+case class Schema(name: String, format: SchemaFormat)
+
+object Schema:
+  def json(name: String): Schema = Schema(name, SchemaFormat.Json)
+
+enum SchemaFormat:
+  case Json, Protobuf, Avro, Bytes
+
+enum PropertyValue:
+  case Str(value: String)
+  case Num(value: Double)
+  case Bool(value: Boolean)
+
+/** Validated user properties. Keys must be non-empty and must not use the reserved `$` prefix -
+  * the server owns that namespace (`$schema.name`, `$schema.format`, ...).
+  */
+case class Properties private (toMap: Map[String, PropertyValue]):
+  def isEmpty: Boolean = toMap.isEmpty
+
+object Properties:
+
+  val empty: Properties = new Properties(Map.empty)
+
+  def of(kvs: (String, PropertyValue)*): Either[String, Properties] =
+    val bad = kvs.collect { case (k, _) if k.isEmpty || k.startsWith("$") => k }
+    if bad.isEmpty then Right(new Properties(kvs.toMap))
+    else Left(s"Invalid property keys (empty or reserved '$$' prefix): ${bad.mkString(", ")}")
+
+/** Append to one stream with a mandatory expectation: unlike the raw protocol, where records and
+  * checks are independent lists, a check is always attached to every written stream.
+  */
+case class StreamAppend(
+  streamId: StreamId.Id,
+  expected: StreamState,
+  records: NonEmptyList[RecordData]
+)
+
+/** A consistency condition on a stream that is not written to (dynamic consistency boundary):
+  * the whole append succeeds only if the guarded stream satisfies [[StreamGuard.expected]].
+  */
+case class StreamGuard(streamId: StreamId.Id, expected: StreamState)
+
+/** @param position
+  *   the log position of the committed transaction. The v2 protocol reports a single position,
+  *   unlike v1's commit / prepare pair; it is mapped as commit == prepare.
+  */
+case class MultiAppendResult(
+  position: LogPosition.Exact,
+  revisions: NonEmptyList[(StreamId.Id, StreamPosition.Exact)]
+)

--- a/fs2/src/main/scala/sec/api/client.scala
+++ b/fs2/src/main/scala/sec/api/client.scala
@@ -24,6 +24,7 @@ import cats.effect.{Async, Resource}
 import com.comcast.ip4s.{Hostname, Port}
 import io.kurrent.dbclient.proto.gossip.GossipFs2Grpc
 import io.kurrent.dbclient.proto.streams.{ReadReq, ReadResp, StreamsFs2Grpc}
+import io.kurrentdb.protocol.v2.streams.StreamsServiceFs2Grpc
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.noop.NoOpLogger
 import io.grpc.{CallOptions, ManagedChannel, Metadata}
@@ -33,6 +34,7 @@ import cats.effect.std.Dispatcher
 import sec.api.pool.{CallCounter, GrpcChannelPool, GrpcSlot, Pool, SubscriptionPool}
 import sec.api.exceptions.{NotLeader, ServerUnavailable}
 import sec.api.grpc.convert.convertToEs
+import sec.api.grpc.convertV2
 import sec.api.grpc.metadata.*
 import sec.api.retries.RetryConfig
 import sec.api.cluster.ClusterEndpoints
@@ -126,6 +128,7 @@ object EsClient:
                    CallCounter.of[F](sp.config.streamsPerChannel, logger.withModifiedString(s => s"OpsChannel > $s"))
                  })
       s    <- mkStreamsFs2Grpc[F](mc, options.prefetchN, middleware = counter.map(_.middleware))
+      s2   <- mkStreamsV2Fs2Grpc[F](mc, middleware = counter.map(_.middleware))
       g    <- mkGossipFs2Grpc[F](mc, middleware = counter.map(_.middleware))
       pool <- subscriptionPool.traverse { sp =>
                 GrpcChannelPool.of[F](
@@ -135,10 +138,11 @@ object EsClient:
                   logger.withModifiedString(s => s"SubscriptionPool > $s")
                 )
               }
-    yield create[F](s, g, options, requiresLeader, logger, refreshHint, pool)
+    yield create[F](s, s2, g, options, requiresLeader, logger, refreshHint, pool)
 
   private[sec] def create[F[_]: Async](
     streamsFs2Grpc: StreamsFs2Grpc[F, Context],
+    streamsV2Fs2Grpc: StreamsServiceFs2Grpc[F, Context],
     gossipFs2Grpc: GossipFs2Grpc[F, Context],
     options: Options,
     requiresLeader: Boolean,
@@ -163,6 +167,7 @@ object EsClient:
 
     val streams: Streams[F] = Streams(
       streamsFs2Grpc,
+      streamsV2Fs2Grpc,
       mkContext(options, requiresLeader),
       mkOpts[F](options.operationOptions, logger, "Streams", refreshHint),
       subscriptionTransport
@@ -216,6 +221,22 @@ object EsClient:
       .withPrefetchN(prefetchN)
 
     Dispatcher.parallel[F].map(StreamsFs2Grpc.mkClientFull[F, F, Context](_, mc, aspect(middleware), clientOptions))
+
+  private[sec] def mkStreamsV2Fs2Grpc[F[_]: Async](
+    mc: ManagedChannel,
+    fn: Endo[CallOptions] = identity,
+    middleware: Option[ClientAspectMiddleware[F, Metadata]] = None
+  ): Resource[F, StreamsServiceFs2Grpc[F, Context]] =
+
+    // v2 errors carry structured details (see convertV2); anything unrecognized falls back to
+    // the common v1 conversion, e.g. server unavailability.
+    val clientOptions = ClientOptions.default
+      .configureCallOptions(fn)
+      .withErrorAdapter(Function.unlift(ex => convertV2.convertToEs(ex) orElse convertToEs(ex)))
+
+    Dispatcher
+      .parallel[F]
+      .map(StreamsServiceFs2Grpc.mkClientFull[F, F, Context](_, mc, aspect(middleware), clientOptions))
 
   /// Gossip
 

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -24,6 +24,8 @@ import cats.data.*
 import cats.effect.*
 import cats.syntax.all.*
 import io.kurrent.dbclient.proto.streams.*
+import io.kurrentdb.protocol.v2.streams.StreamsServiceFs2Grpc
+import io.kurrentdb.protocol.v2.streams.{AppendRecordsRequest as V2AppendReq, AppendRecordsResponse as V2AppendResp}
 import fs2.{Pipe, Pull, RaiseThrowable, Stream}
 import org.typelevel.log4cats.Logger
 import sec.api.exceptions.{ResubscriptionRequired, WrongExpectedVersion}
@@ -158,6 +160,36 @@ trait Streams[F[_]]:
     data: NonEmptyList[EventData]
   ): F[WriteResult]
 
+  /** Experimental - the underlying v2 protocol is marked unstable by KurrentDB and may change;
+    * this API may change with it.
+    *
+    * Appends records to one or more streams atomically; the server must support and have enabled
+    * the v2 protocol. Every written stream carries a mandatory [[StreamState]] expectation, and
+    * [[sec.api.StreamGuard]] expresses conditions on streams that are read from but not written
+    * to: below, the reservation is appended only if the flight stream is still at revision 42,
+    * although nothing is written to it (dynamic consistency boundary).
+    *
+    * {{{
+    * client.streams.multiStreamAppend(
+    *   appends = NonEmptyList.one(StreamAppend(reservationId, StreamState.NoStream, records)),
+    *   guards  = List(StreamGuard(flightId, StreamPosition(42L)))
+    * )
+    * }}}
+    *
+    * Failure to fulfill a check is manifested by raising
+    * [[sec.api.exceptions.AppendConsistencyViolation]]. Streams must be distinct across appends
+    * and guards; duplicates raise [[sec.api.exceptions.DuplicateStreams]].
+    *
+    * @param appends
+    *   the streams to append to, each with an expectation and its records. See [[sec.api.StreamAppend]].
+    * @param guards
+    *   consistency conditions on unwritten streams. See [[sec.api.StreamGuard]].
+    */
+  def multiStreamAppend(
+    appends: NonEmptyList[StreamAppend],
+    guards: List[StreamGuard] = Nil
+  ): F[MultiAppendResult]
+
   /** Deletes a stream and returns [[DeleteResult]] with current log position after a successful operation. Failure to
     * fulfill the expected state is manifested by raising [[sec.api.exceptions.WrongExpectedState]].
     *
@@ -220,16 +252,18 @@ object Streams:
 
   private[sec] def apply[F[_]: Temporal, C](
     client: StreamsFs2Grpc[F, C],
+    clientV2: StreamsServiceFs2Grpc[F, C],
     mkCtx: Option[UserCredentials] => C,
     opts: Opts[F],
     subscriptionTransport: Option[(ReadReq, C) => Stream[F, ReadResp]] = None
   ): Streams[F] = new Streams[F]:
 
     private given C = mkCtx(None)
-    private val read   = client.read(_)
-    private val append = client.append(_)
-    private val delete = client.delete(_)
-    private val tomb   = client.tombstone(_)
+    private val read     = client.read(_)
+    private val append   = client.append(_)
+    private val appendV2 = clientV2.appendRecords(_)
+    private val delete   = client.delete(_)
+    private val tomb     = client.tombstone(_)
 
     // Subscriptions are infinite streams and may route over a pooled transport (see sec.api.pool)
     // instead of the ops channel. Reads/appends/gossip stay on the dedicated ops channel: transient
@@ -295,6 +329,12 @@ object Streams:
     ): F[WriteResult] =
       appendToStream0[F](streamId, expectedState, data, opts)(append)
 
+    def multiStreamAppend(
+      appends: NonEmptyList[StreamAppend],
+      guards: List[StreamGuard]
+    ): F[MultiAppendResult] =
+      multiStreamAppend0[F](appends, guards, opts)(appendV2)
+
     def delete(
       streamId: StreamId,
       expectedState: StreamState
@@ -310,7 +350,7 @@ object Streams:
     def withCredentials(
       creds: UserCredentials
     ): Streams[F] =
-      Streams[F, C](client, _ => mkCtx(creds.some), opts, subscriptionTransport)
+      Streams[F, C](client, clientV2, _ => mkCtx(creds.some), opts, subscriptionTransport)
 
     val messageReads: Reads[F] =
       Reads[F, C](client, mkCtx)
@@ -389,6 +429,24 @@ object Streams:
     val operation: F[AppendResp] = f(Stream.emit(header) ++ Stream.emits(events))
 
     opts.run(operation, "appendToStream") >>= { ar => mkWriteResult[F](streamId, ar) }
+
+  private[sec] def multiStreamAppend0[F[_]: Temporal](
+    appends: NonEmptyList[StreamAppend],
+    guards: List[StreamGuard],
+    opts: Opts[F]
+  )(f: V2AppendReq => F[V2AppendResp]): F[MultiAppendResult] =
+
+    // Duplicates across appends and guards would place multiple, potentially conflicting, checks
+    // on one stream - an illegal state the collection types cannot rule out, so it is rejected here.
+    val ids  = appends.toList.map(_.streamId.stringValue) ++ guards.map(_.streamId.stringValue)
+    val dups = ids.groupBy(identity).collect { case (id, xs) if xs.sizeIs > 1 => id }.toList.sorted
+
+    dups match
+      case Nil =>
+        val req = mapping.streamsV2.mkAppendRecordsRequest(appends, guards)
+        opts.run(f(req), "multiStreamAppend") >>= mapping.streamsV2.mkMultiAppendResult[F](appends)
+      case ds =>
+        exceptions.DuplicateStreams(ds).raiseError
 
   private[sec] def delete0[F[_]: Temporal](
     streamId: StreamId,

--- a/protobuf/kurrentdb/protocol/v2/rpc.proto
+++ b/protobuf/kurrentdb/protocol/v2/rpc.proto
@@ -1,0 +1,77 @@
+﻿// ******************************************************************************************
+// This protocol is UNSTABLE in the sense of being subject to change.
+// ******************************************************************************************
+
+syntax = "proto3";
+
+package kurrent.rpc;
+
+option go_package = "github.com/kurrent-io/KurrentDB-Client-Go/protos/rpc";
+option csharp_namespace = "Kurrent.Rpc";
+option java_package        = "io.kurrent.rpc";
+option java_multiple_files = true;
+
+import "google/protobuf/descriptor.proto";
+import "google/rpc/code.proto";
+
+// ErrorMetadata provides actionable information for error enum values to enable automated
+// code generation, documentation, and consistent error handling across the Kurrent platform.
+//
+// It was modeled to support a single details type per error code to simplify code generation and
+// validation. If multiple detail types are needed for a single error code, consider defining
+// separate error codes for each detail type. Or, use a union type (oneof) in the detail message
+// to encapsulate multiple detail variants within a single detail message.
+//
+// More however DebugInfo and RetryInfo can and should be added to any error regardless of
+// this setting, when applicable.
+//
+// This annotation is applied to enum values using the google.protobuf.EnumValueOptions
+// extension mechanism. It enables:
+// - Automatic gRPC status code mapping
+// - Code generation for error handling utilities
+// - Documentation generation
+// - Type-safe error detail validation
+//
+// Usage Example:
+//   enum StreamErrorCode {
+//     REVISION_CONFLICT = 5 [(kurrent.rpc.error) = {
+//       status_code: FAILED_PRECONDITION,
+//       has_details: true
+//     }];
+//   }
+//
+// See individual field documentation for conventions and defaults.
+message ErrorMetadata {
+  // Maps the error to a standard gRPC status code for transport-level compatibility.
+  // This field is REQUIRED for every error annotation.
+  //
+  // Use standard gRPC status codes from `google.rpc.code`.
+  //
+  // Code generators use this to:
+  // - Map errors to gRPC status codes automatically
+  // - Generate HTTP status code mappings
+  // - Create transport-agnostic error handling
+  google.rpc.Code status_code = 1;
+
+  // Indicates whether this error supports rich, typed detail messages.
+  // Defaults to false (simple message string only).
+  // The message type name must be derived from the enum name by convention.
+  // Mask: {EnumValue}ErrorDetails, {EnumValue}Error, {EnumValue}
+  //
+  // Examples:
+  //   ACCESS_DENIED    -> "AccessDeniedErrorDetails", "AccessDeniedError" or "AccessDenied"
+  //   SERVER_NOT_READY -> "ServerNotReadyErrorDetails", "ServerNotReadyError" or "ServerNotReady"
+  //
+  // Code generators use the message type name to:
+  // - Validate that the detail message matches the expected type
+  // - Generate type-safe error handling code
+  // - Create accurate documentation
+  bool has_details = 2;
+}
+
+// Extend EnumValueOptions to include error information for enum values
+extend google.protobuf.EnumValueOptions {
+  // Provides additional information about error conditions for automated
+  // code generation and documentation.
+  optional ErrorMetadata error = 2113;
+}

--- a/protobuf/kurrentdb/protocol/v2/streams/errors.proto
+++ b/protobuf/kurrentdb/protocol/v2/streams/errors.proto
@@ -1,0 +1,263 @@
+// ******************************************************************************************
+// This protocol is UNSTABLE in the sense of being subject to change.
+// ******************************************************************************************
+
+syntax = "proto3";
+
+package kurrentdb.protocol.v2.streams.errors;
+
+option go_package = "github.com/kurrent-io/KurrentDB-Client-Go/protos/kurrentdb/protocols/v2/streams";
+option csharp_namespace = "KurrentDB.Protocol.V2.Streams.Errors";
+option java_package        = "io.kurrentdb.protocol.v2.streams.errors";
+option java_multiple_files = true;
+
+import "kurrentdb/protocol/v2/rpc.proto";
+
+// Error codes specific to the Streams API.
+// These errors represent failure modes when working with streams of records.
+enum StreamsError {
+  // Default value. This value is not used.
+  // An error code MUST always be set to a non-zero value.
+  // If an error code is not explicitly set, it MUST be treated as
+  // an internal server error (INTERNAL).
+  STREAMS_ERROR_UNSPECIFIED = 0;
+
+  // The requested stream does not exist in the database.
+  //
+  // Common causes:
+  // - Stream name typo or incorrect stream identifier
+  // - Stream was never created (no events appended yet)
+  // - Stream was deleted and not yet recreated
+  //
+  // Client action: Verify the stream name is correct. Create the stream by appending to it.
+  // Recoverable by creating the stream first (append with NO_STREAM expected revision).
+  STREAMS_ERROR_STREAM_NOT_FOUND = 1 [(kurrent.rpc.error) = {
+    status_code: NOT_FOUND,
+    has_details: true,
+  }];
+
+  // The stream already exists when an operation expected it not to exist.
+  //
+  // Common causes:
+  // - Attempting to create a stream that already has events
+  // - Using NO_STREAM expected revision on an existing stream
+  // - Race condition with concurrent stream creation
+  //
+  // Client action: Use the existing stream or use a different expected revision.
+  // Recoverable by adjusting the expected revision or using the existing stream.
+  STREAMS_ERROR_STREAM_ALREADY_EXISTS = 2 [(kurrent.rpc.error) = {
+    status_code: ALREADY_EXISTS,
+    has_details: true
+  }];
+
+  // The stream has been soft deleted.
+  // Soft-deleted streams are hidden from stream lists but can be restored by appending to them.
+  //
+  // Common causes:
+  // - Stream was explicitly soft-deleted via delete operation
+  // - Attempting to read from a soft-deleted stream
+  //
+  // Client action: Restore the stream by appending new events, or accept that the stream is deleted.
+  // Recoverable by appending to the stream to restore it.
+  STREAMS_ERROR_STREAM_DELETED = 3 [(kurrent.rpc.error) = {
+    status_code: FAILED_PRECONDITION,
+    has_details: true
+  }];
+
+  // The stream has been tombstoned (permanently deleted).
+  // Tombstoned streams cannot be restored and will never accept new events.
+  //
+  // Common causes:
+  // - Stream was explicitly tombstoned via tombstone operation
+  // - Administrative deletion of sensitive data
+  // - Attempting to write to or read from a tombstoned stream
+  //
+  // Client action: Stream is permanently removed. Create a new stream with a different name if needed.
+  // Not recoverable - the stream cannot be restored.
+  STREAMS_ERROR_STREAM_TOMBSTONED = 4 [(kurrent.rpc.error) = {
+    status_code: FAILED_PRECONDITION,
+    has_details: true
+  }];
+
+  // The expected revision does not match the actual stream revision.
+  // This is an optimistic concurrency control failure.
+  //
+  // Common causes:
+  // - Another client modified the stream concurrently
+  // - Client has stale state about the stream revision
+  // - Race condition in distributed system
+  //
+  // Client action: Fetch the current stream revision and retry with the correct expected revision.
+  // Recoverable by reading the current state and retrying with proper optimistic concurrency control.
+  STREAMS_ERROR_STREAM_REVISION_CONFLICT = 5 [(kurrent.rpc.error) = {
+    status_code: FAILED_PRECONDITION,
+    has_details: true
+  }];
+
+  // A single record being appended exceeds the maximum allowed size.
+  //
+  // Common causes:
+  // - Record payload is too large (exceeds server's max record size configuration)
+  // - Excessive metadata in properties
+  // - Large binary data without chunking
+  //
+  // Client action: Reduce record size, split large payloads across multiple records, or increase server limits.
+  // Recoverable by reducing record size or adjusting server configuration.
+  STREAMS_ERROR_APPEND_RECORD_SIZE_EXCEEDED = 6 [(kurrent.rpc.error) = {
+    status_code: INVALID_ARGUMENT,
+    has_details: true
+  }];
+
+  // The total size of all records in a single append session exceeds the maximum allowed transaction size.
+  //
+  // Common causes:
+  // - Too many records in a single append session
+  // - Combined payload size exceeds server's max transaction size
+  // - Attempting to write very large batches
+  //
+  // Client action: Split the append into multiple smaller transactions.
+  // Recoverable by reducing the number of records per append session.
+  STREAMS_ERROR_APPEND_TRANSACTION_SIZE_EXCEEDED = 7 [(kurrent.rpc.error) = {
+    status_code: ABORTED,
+    has_details: true
+  }];
+
+  // The same stream appears multiple times in a single append session.
+  // This is currently not supported to prevent complexity with expected revisions and ordering.
+  //
+  // Common causes:
+  // - Accidentally appending to the same stream twice in one session
+  // - Application logic error in batch operations
+  //
+  // Client action: Remove duplicate streams from the append session or split into multiple sessions.
+  // Recoverable by restructuring the append session to reference each stream only once.
+  STREAMS_ERROR_STREAM_ALREADY_IN_APPEND_SESSION = 8 [(kurrent.rpc.error) = {
+    status_code: ABORTED,
+    has_details: true
+  }];
+
+  // An append session was started but no append requests were sent before completing the stream.
+  //
+  // Common causes:
+  // - Client completed the stream without sending any AppendRequest messages
+  // - Application logic error
+  //
+  // Client action: Ensure at least one AppendRequest is sent before completing the stream.
+  // Recoverable by properly implementing the append session protocol.
+  STREAMS_ERROR_APPEND_SESSION_NO_REQUESTS = 9 [(kurrent.rpc.error) = {
+    status_code: FAILED_PRECONDITION
+  }];
+
+  // One or more consistency checks failed during an AppendRecords operation.
+  // The transaction is aborted — no records are written.
+  //
+  // Common causes:
+  // - A stream state check found the stream at a different revision than expected
+  // - A stream referenced in a state check does not exist, was deleted, or was tombstoned
+  //
+  // Client action: Inspect the AppendConsistencyViolationErrorDetails to determine which
+  // checks failed and why, then correct the request or refresh local state and retry.
+  // Recoverable by reading the current state and resubmitting with updated checks.
+  STREAMS_ERROR_APPEND_CONSISTENCY_VIOLATION = 14 [(kurrent.rpc.error) = {
+    status_code: FAILED_PRECONDITION,
+    has_details: true
+  }];
+}
+
+// Details for STREAM_NOT_FOUND errors.
+message StreamNotFoundErrorDetails {
+  // The name of the stream that was not found.
+  string stream = 1;
+}
+
+// Details for STREAM_ALREADY_EXISTS errors.
+message StreamAlreadyExistsErrorDetails {
+  // The name of the stream that already exists.
+  string stream = 1;
+}
+
+// Details for STREAM_DELETED errors.
+message StreamDeletedErrorDetails {
+  // The name of the stream that was deleted.
+  string stream = 1;
+}
+
+// Details for STREAM_TOMBSTONED errors.
+message StreamTombstonedErrorDetails {
+  // The name of the stream that was tombstoned.
+  string stream = 1;
+}
+
+// Details for STREAM_REVISION_CONFLICT errors.
+message StreamRevisionConflictErrorDetails {
+  // The name of the stream that had a revision conflict.
+  string stream = 1;
+
+  // The expected revision that was provided in the append request.
+  sint64 expected_revision = 2 [jstype = JS_STRING];
+
+  // The actual current revision of the stream.
+  sint64 actual_revision = 3 [jstype = JS_STRING];
+}
+
+// Details for APPEND_RECORD_SIZE_EXCEEDED errors.
+message AppendRecordSizeExceededErrorDetails {
+  // The name of the stream where the append was attempted.
+  string stream = 1;
+
+  // The identifier of the record that exceeded the size limit.
+  string record_id = 2;
+
+  // The actual size of the record in bytes.
+  int32 size = 3;
+
+  // The maximum allowed size of a single record in bytes.
+  int32 max_size = 4;
+}
+
+// Details for APPEND_TRANSACTION_SIZE_EXCEEDED errors.
+message AppendTransactionSizeExceededErrorDetails {
+  // The actual size of the transaction in bytes.
+  int32 size = 1;
+
+  // The maximum allowed size of an append transaction in bytes.
+  int32 max_size = 2;
+}
+
+// Details for STREAM_ALREADY_IN_APPEND_SESSION errors.
+message StreamAlreadyInAppendSessionErrorDetails {
+  // The name of the stream that appears multiple times.
+  string stream = 1;
+}
+
+// Details for APPEND_CONSISTENCY_VIOLATION errors.
+//
+// Contains all consistency checks that were violated during the append operation.
+// Only violated checks are included; satisfied checks are omitted.
+message AppendConsistencyViolationErrorDetails {
+  // The consistency checks that were violated.
+  repeated ConsistencyViolation violations = 1;
+}
+
+// Details for a single consistency check that was violated.
+message ConsistencyViolation {
+  // Index of the check in the original consistency_checks list.
+  int32 check_index = 1;
+
+  oneof type {
+    // The stream was not at the expected state.
+    StreamStateViolation stream_state = 2;
+  }
+
+  // A stream state check was violated because the actual state did not match the expected state.
+  message StreamStateViolation {
+    // The name of the stream whose state was checked.
+    string stream = 1;
+
+    // The expected state of the stream as specified in the consistency check.
+    sint64 expected_state = 2 [jstype = JS_STRING];
+
+    // The actual state of the stream at the time the check was evaluated.
+    sint64 actual_state = 3 [jstype = JS_STRING];
+  }
+}

--- a/protobuf/kurrentdb/protocol/v2/streams/streams.proto
+++ b/protobuf/kurrentdb/protocol/v2/streams/streams.proto
@@ -1,0 +1,241 @@
+// ******************************************************************************************
+// This protocol is UNSTABLE in the sense of being subject to change.
+// ******************************************************************************************
+
+syntax = "proto3";
+
+package kurrentdb.protocol.v2.streams;
+
+option go_package = "github.com/kurrent-io/KurrentDB-Client-Go/protos/kurrentdb/protocols/v2/streams";
+option csharp_namespace    = "KurrentDB.Protocol.Streams.V2";
+option java_package        = "io.kurrentdb.protocol.v2.streams";
+option java_multiple_files = true;
+
+import "google/protobuf/struct.proto";
+
+service StreamsService {
+  // Appends records to multiple streams atomically within a single transaction.
+  //
+  // This is a client-streaming RPC where the client sends multiple AppendRequest messages
+  // (one per stream) and receives a single AppendSessionResponse upon commit.
+  //
+  // Guarantees:
+  // - Atomicity: All writes succeed or all fail together
+  // - Optimistic Concurrency: Expected revisions are validated for all streams before commit
+  // - Ordering: Records within each stream maintain send order
+  //
+  // Current Limitations:
+  // - Each stream can only appear once per session (no multiple appends to same stream)
+  //
+  // Example flow:
+  //   1. Client opens stream
+  //   2. Client sends AppendRequest for stream "orders" with 3 records
+  //   3. Client sends AppendRequest for stream "inventory" with 2 records
+  //   4. Client completes the stream
+  //   5. Server validates, commits, returns AppendSessionResponse with positions
+  rpc AppendSession(stream AppendRequest) returns (AppendSessionResponse);
+
+  // Appends records to multiple streams atomically with cross-stream consistency checks.
+  //
+  // This is a unary RPC where the client sends all records and consistency checks
+  // in a single request and receives a single AppendRecordsResponse.
+  //
+  // Records can be interleaved across streams in any order and the global log preserves
+  // the exact sequence from the request.
+  //
+  // Consistency checks are decoupled from writes: a check can reference any stream,
+  // whether or not the request writes to it.
+  //
+  // Guarantees:
+  // - Atomicity: All writes succeed or all fail together
+  // - Ordering: Records maintain the exact send order in the global log
+  // - Cross-stream checks: Consistency checks can reference any stream
+  //
+  // On consistency check failure, no records are written and all failing checks
+  // are reported in the response so the client can refresh stale state in one round trip.
+  rpc AppendRecords(AppendRecordsRequest) returns (AppendRecordsResponse);
+}
+
+// Represents the input for appending records to a specific stream.
+message AppendRequest {
+  // The stream to append records to.
+  string stream = 1;
+
+  // The records to append to the stream.
+  repeated AppendRecord records = 2;
+
+  // The expected revision for optimistic concurrency control.
+  // Can be either:
+  // - A specific revision number (0, 1, 2, ...) - the stream must be at exactly this revision
+  // - An ExpectedRevisionConstants value (-4, -2, -1) for special semantics
+  //
+  // If omitted, defaults to EXPECTED_REVISION_CONSTANTS_ANY (-2).
+  optional sint64 expected_revision = 3 [jstype = JS_STRING];
+}
+
+// Represents the outcome of an append operation.
+message AppendResponse {
+  // The stream to which records were appended.
+  string stream = 1;
+
+  // The actual/current revision of the stream after the append.
+  // This is the revision number of the last record written to this stream.
+  sint64 stream_revision = 2 [jstype = JS_STRING];
+
+  // The position of the last appended record in the global log.
+  optional sint64 position = 3 [jstype = JS_STRING];
+}
+
+message AppendSessionResponse {
+  // The results of each append request in the session.
+  repeated AppendResponse output = 1;
+
+  // The global commit position of the last appended record in the session.
+  sint64 position = 2 [jstype = JS_STRING];
+}
+
+// Represents the data format of the schema.
+enum SchemaFormat {
+  // Default value, should not be used.
+  SCHEMA_FORMAT_UNSPECIFIED = 0;
+  SCHEMA_FORMAT_JSON        = 1;
+  SCHEMA_FORMAT_PROTOBUF    = 2;
+  SCHEMA_FORMAT_AVRO        = 3;
+  SCHEMA_FORMAT_BYTES       = 4;
+}
+
+// Schema information for record validation and interpretation.
+message SchemaInfo {
+  // The format of the data payload.
+  // Determines how the bytes in AppendRecord.data should be interpreted.
+  SchemaFormat format = 1;
+
+  // The schema name (replaces the legacy "event type" concept).
+  // Identifies what kind of data this record contains.
+  //
+  // Common naming formats:
+  //   - Kebab-case: "order-placed", "customer-registered"
+  //   - URN format: "urn:kurrentdb:events:order-placed:v1"
+  //   - Dotted namespace: "Teams.Player.V1", "Orders.OrderPlaced.V2"
+  //   - Reverse domain: "com.acme.orders.placed"
+  string name = 2;
+
+  // The identifier of the specific version of the schema that the record payload
+  // conforms to. This should match a registered schema version in the system.
+  // Not necessary when not enforcing schema validation.
+  optional string id = 3;
+}
+
+// Record to be appended to a stream.
+message AppendRecord {
+  // Unique identifier for this record (must be a valid UUID/GUID).
+  // If not provided, the server will generate a new one.
+  optional string record_id = 1;
+
+  // A collection of properties providing additional information about the
+  // record. Can contain user-defined or system propreties.
+  // System keys will be prefixed with "$" (e.g., "$timestamp").
+  // User-defined keys MUST NOT start with "$".
+  //
+  // Common examples:
+  //   User metadata:
+  //     - "user-id": "12345"
+  //     - "tenant": "acme-corp"
+  //     - "source": "mobile-app"
+  //
+  //   System metadata (with $ prefix):
+  //     - "$trace-id": "4bf92f3577b34da6a3ce929d0e0e4736"  // OpenTelemetry trace ID
+  //     - "$span-id": "00f067aa0ba902b7"                   // OpenTelemetry span ID
+  //     - "$timestamp": "2025-01-15T10:30:00.000Z"         // ISO 8601 timestamp
+  map<string, google.protobuf.Value> properties = 2;
+
+  // Schema information for this record.
+  SchemaInfo schema = 3;
+
+  // The record payload as raw bytes.
+  // The format specified in SchemaInfo determines how to interpret these bytes.
+  bytes data = 4;
+
+  // Target stream for this record.
+  // Required for AppendRecords (each record specifies its own stream).
+  // Ignored for AppendSession (the stream is specified in AppendRequest).
+  string stream = 5;
+}
+
+// Constants for expected revision validation in optimistic concurrency control.
+// These can be used in the expected_revision field, or you can specify an actual revision number.
+enum ExpectedRevisionConstants {
+  // The stream must have exactly one event at revision 0.
+  // Used for scenarios requiring strict single-event semantics.
+  EXPECTED_REVISION_CONSTANTS_SINGLE_EVENT = 0;
+
+  // The stream must not exist yet (first write to the stream).
+  // Fails if the stream already has events.
+  EXPECTED_REVISION_CONSTANTS_NO_STREAM = -1;
+
+  // Accept any current state of the stream (no optimistic concurrency check).
+  // The write will succeed regardless of the stream's current revision.
+  EXPECTED_REVISION_CONSTANTS_ANY = -2;
+
+  // The stream must exist (have at least one record).
+  // Fails if the stream doesn't exist yet.
+  EXPECTED_REVISION_CONSTANTS_EXISTS = -4;
+}
+
+// Request to append records to one or more streams atomically.
+//
+// All records are committed in a single transaction. Each record specifies its
+// target stream via AppendRecord.stream. Consistency checks are evaluated before
+// any records are written.
+message AppendRecordsRequest {
+  // The records to append. Records targeting the same stream maintain their
+  // order from this list.
+  repeated AppendRecord records = 1;
+
+  // Optional consistency checks evaluated before commit. If any check fails,
+  // the entire transaction is aborted.
+  repeated ConsistencyCheck checks = 2;
+}
+
+// Response from a successful AppendRecords operation.
+//
+// Contains the resulting revision for each stream that was written to and the
+// global commit position of the transaction.
+message AppendRecordsResponse {
+  // The resulting revision for each stream that received records. One entry per
+  // distinct stream written to, in no guaranteed order.
+  repeated StreamRevision revisions = 1;
+
+  // The global commit position of the last record written in this transaction.
+  // Can be used for read-your-writes consistency or progress tracking.
+  sint64 position = 2 [jstype = JS_STRING];
+}
+
+// A pre-commit condition that must hold true for the transaction to succeed.
+//
+// Consistency checks are evaluated atomically before any records are written. If
+// any check is violated, the entire transaction is aborted.
+message ConsistencyCheck {
+  oneof type {
+    // Check that a stream is at a specific revision or lifecycle state.
+    StreamStateCheck stream_state = 1;
+  }
+
+  // Asserts a stream is at a specific revision or lifecycle state before commit.
+  message StreamStateCheck {
+    // The stream name.
+    string stream = 1;
+
+    // The expected state of the stream (revision number or state constant).
+    sint64 expected_state = 2 [jstype = JS_STRING];
+  }
+}
+
+// A specific revision of a stream.
+message StreamRevision {
+  // Stream name.
+  string stream = 1;
+
+  // Revision within the stream.
+  sint64 revision = 2 [jstype = JS_STRING];
+}

--- a/tests/src/fit/scala/sec/api/streams/multiStreamAppend.scala
+++ b/tests/src/fit/scala/sec/api/streams/multiStreamAppend.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import cats.syntax.all.*
+import cats.effect.{IO, Resource}
+import com.google.protobuf.ByteString
+import com.google.protobuf.struct.Value
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
+import io.grpc.{Metadata, Status, StatusRuntimeException}
+import io.kurrentdb.protocol.v2.streams.*
+import scodec.bits.ByteVector
+import sec.api.exceptions.StreamNotFound
+
+/** Fault-harness coverage for v2 multi-stream append against a real node: v1 read roundtrip of
+  * v2-written records, user-property metadata synthesis, request atomicity, guard semantics on
+  * unwritten streams, and typed error surfacing through the client API. The raw-stub tests
+  * intentionally remain: they pin the wire-level behavior the public API is built on.
+  */
+class MultiStreamAppendSuite extends FSuite:
+
+  final private val schemaName = "fit-spike-event"
+  final private val payload    = """{"n":1}"""
+
+  private def v2Stub: Resource[IO, StreamsServiceFs2Grpc[IO, Metadata]] =
+    Resource
+      .make(IO.blocking {
+        NettyChannelBuilder.forAddress(node.endpoint.address, node.endpoint.port).usePlaintext().build()
+      })(ch => IO.blocking { ch.shutdownNow(); () })
+      .flatMap(StreamsServiceFs2Grpc.stubResource[IO](_))
+
+  private def record(stream: String): AppendRecord =
+    AppendRecord(
+      recordId   = Some(java.util.UUID.randomUUID().toString),
+      properties = Map.empty,
+      schema     = Some(SchemaInfo(format = SchemaFormat.SCHEMA_FORMAT_JSON, name = schemaName)),
+      data       = ByteString.copyFromUtf8(payload),
+      stream     = stream
+    )
+
+  private def noStream(stream: String): ConsistencyCheck =
+    ConsistencyCheck().withStreamState(ConsistencyCheck.StreamStateCheck(stream = stream, expectedState = -1L))
+
+  /** Distinguishes "feature not enabled" from any other failure. */
+  private def explained[A](fa: IO[A]): IO[A] =
+    fa.adaptError {
+      case e: StatusRuntimeException if e.getStatus.getCode == Status.Code.UNIMPLEMENTED =>
+        new AssertionError(
+          "v2 StreamsService.AppendRecords is not enabled on this server",
+          e
+        )
+    }
+
+  test("v2 append with NoStream check roundtrips through v1 reads") {
+    (v2Stub, mkClient()).tupled.use { case (stub, client) =>
+      given Metadata = new Metadata()
+
+      val sid  = genStreamId("fit_v2_rt_")
+      val name = sid.stringValue
+      val req  = AppendRecordsRequest(records = Seq(record(name)), checks = Seq(noStream(name)))
+
+      for
+        resp <- explained(stub.appendRecords(req))
+        _    <- IO(assertEquals(resp.revisions.toList, List(StreamRevision(name, 0L))))
+        _    <- IO(assert(resp.position >= 0L, s"expected a log position, got ${resp.position}"))
+        evs  <- client.streams
+                  .readStream(sid, StreamPosition.Start, Direction.Forwards, 10L, resolveLinkTos = false)
+                  .compile
+                  .toList
+        _    <- IO(assertEquals(evs.size, 1, s"expected one event via v1 read, got: $evs"))
+        ed    = evs.head.record.eventData
+        _    <- IO(assertEquals(
+                  ed.data,
+                  ByteVector.view(payload.getBytes("UTF-8")),
+                  "payload bytes must roundtrip v2-append -> v1-read unchanged"
+                ))
+        _    <- IO(assertEquals(
+                  ed.eventType.stringValue,
+                  schemaName,
+                  s"hypothesis: v1 eventType == v2 schema name; actual mapping: ${ed.eventType.stringValue}"
+                ))
+        _    <- IO.println(s"[v2] v1 view of v2 record: contentType=${ed.contentType}, metadata=${ed.metadata}")
+      yield ()
+    }
+  }
+
+  test("v2 user properties materialize in the v1 metadata view") {
+    (v2Stub, mkClient()).tupled.use { case (stub, client) =>
+      given Metadata = new Metadata()
+
+      val sid  = genStreamId("fit_v2_props_")
+      val name = sid.stringValue
+      // v2 has no raw metadata bytes: the server synthesizes v1 metadata as JSON with
+      // $schema.* keys. This decides whether user properties merge into that same object.
+      val rec = record(name).copy(properties =
+        Map(
+          "tenant"  -> Value(Value.Kind.StringValue("acme")),
+          "attempt" -> Value(Value.Kind.NumberValue(2)),
+          "replay"  -> Value(Value.Kind.BoolValue(true))
+        )
+      )
+
+      for
+        _    <- explained(stub.appendRecords(AppendRecordsRequest(Seq(rec), Seq(noStream(name)))))
+        evs  <- client.streams
+                  .readStream(sid, StreamPosition.Start, Direction.Forwards, 10L, resolveLinkTos = false)
+                  .compile
+                  .toList
+        json  = new String(evs.head.record.eventData.metadata.toArray, "UTF-8")
+        _    <- IO.println(s"[v2] metadata with user properties: $json")
+        _    <- IO(assert(json.contains("tenant"), s"user properties should surface in v1 metadata; got: $json"))
+      yield ()
+    }
+  }
+
+  test("typed appends and guards map end-to-end and results decode") {
+    (v2Stub, mkClient()).tupled.use { case (stub, client) =>
+      given Metadata = new Metadata()
+      import cats.data.NonEmptyList as CNel
+
+      val aId = genStreamId("fit_v2_map_a_")
+      val bId = genStreamId("fit_v2_map_b_")
+      val gId = genStreamId("fit_v2_map_g_")
+      val cId = genStreamId("fit_v2_map_c_")
+
+      def rec = RecordData(
+        java.util.UUID.randomUUID(),
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.of("tenant" -> PropertyValue.Str("acme")).fold(m => fail(m), identity)
+      )
+
+      val appends = CNel.of(
+        StreamAppend(aId, StreamState.NoStream, CNel.one(rec)),
+        StreamAppend(bId, StreamState.NoStream, CNel.of(rec, rec))
+      )
+
+      // Guard on an unwritten stream, trivially satisfied (gId does not exist yet).
+      val ok = mapping.streamsV2.mkAppendRecordsRequest(appends, List(StreamGuard(gId, StreamState.NoStream)))
+
+      // Violated guard: require gId to exist - it still does not - and assert the violation
+      // names the guarded stream, proving guards work server-side for unwritten streams.
+      val badAppends = CNel.one(StreamAppend(cId, StreamState.NoStream, CNel.one(rec)))
+      val badGuard   = StreamGuard(gId, StreamState.StreamExists)
+      val bad        = mapping.streamsV2.mkAppendRecordsRequest(badAppends, List(badGuard))
+
+      for
+        resp   <- explained(stub.appendRecords(ok))
+        result <- mapping.streamsV2.mkMultiAppendResult[IO](appends)(resp)
+        _      <- IO(assertEquals(
+                    result.revisions.toList.toMap,
+                    Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L))
+                  ))
+        res    <- explained(stub.appendRecords(bad)).attempt
+        _      <- IO(res match
+                    case Left(e: StatusRuntimeException) =>
+                      grpc.convertV2.convertToEs(e) match
+                        case Some(v: exceptions.AppendConsistencyViolation) =>
+                          assertEquals(v.violations.map(_.streamId), List(gId.stringValue))
+                        case other => fail(s"expected AppendConsistencyViolation naming the guard, got $other")
+                    case other => fail(s"expected guard violation, got $other"))
+      yield ()
+    }
+  }
+
+  test("multiStreamAppend raises typed exceptions through the client API") {
+    mkClient().use { client =>
+      import cats.data.NonEmptyList as CNel
+
+      val aId = genStreamId("fit_v2_api_a_")
+      val bId = genStreamId("fit_v2_api_b_")
+
+      def rec = RecordData(
+        java.util.UUID.randomUUID(),
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.empty
+      )
+
+      val appends = CNel.of(
+        StreamAppend(aId, StreamState.NoStream, CNel.one(rec)),
+        StreamAppend(bId, StreamState.NoStream, CNel.of(rec, rec))
+      )
+
+      for
+        r   <- client.streams.multiStreamAppend(appends)
+        _   <- IO(assertEquals(
+                 r.revisions.toList.toMap,
+                 Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L))
+               ))
+        // The error adapter must surface a violated guard as the typed exception directly.
+        bad  = CNel.one(StreamAppend(genStreamId("fit_v2_api_c_"), StreamState.NoStream, CNel.one(rec)))
+        res <- client.streams.multiStreamAppend(bad, List(StreamGuard(aId, StreamState.NoStream))).attempt
+        _   <- IO(res match
+                 case Left(v: exceptions.AppendConsistencyViolation) =>
+                   assertEquals(v.violations.map(_.streamId), List(aId.stringValue))
+                 case other => fail(s"expected typed AppendConsistencyViolation, got $other"))
+      yield ()
+    }
+  }
+
+  test("duplicate streams across appends and guards are rejected client-side") {
+    mkClient().use { client =>
+      import cats.data.NonEmptyList as CNel
+
+      val aId = genStreamId("fit_v2_dup_")
+      val rec = RecordData(
+        java.util.UUID.randomUUID(),
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.empty
+      )
+
+      val appends = CNel.one(StreamAppend(aId, StreamState.NoStream, CNel.one(rec)))
+      client.streams.multiStreamAppend(appends, List(StreamGuard(aId, StreamState.NoStream))).attempt.map {
+        case Left(exceptions.DuplicateStreams(ids)) => assertEquals(ids, List(aId.stringValue))
+        case other                                     => fail(s"expected DuplicateStreams, got $other")
+      }
+    }
+  }
+
+  test("v2 multi-stream append is atomic; a violated check fails the whole request") {
+    (v2Stub, mkClient()).tupled.use { case (stub, client) =>
+      given Metadata = new Metadata()
+
+      val a   = genStreamId("fit_v2_ms_a_").stringValue
+      val bId = genStreamId("fit_v2_ms_b_")
+      val b   = bId.stringValue
+      val cId = genStreamId("fit_v2_ms_c_")
+      val c   = cId.stringValue
+
+      val ok  = AppendRecordsRequest(Seq(record(a), record(b)), Seq(noStream(a), noStream(b)))
+      // a exists after `ok`, so its NoStream check must fail - and c must not be written.
+      val bad = AppendRecordsRequest(Seq(record(c), record(a)), Seq(noStream(c), noStream(a)))
+
+      for
+        resp <- explained(stub.appendRecords(ok))
+        _    <- IO(assertEquals(resp.revisions.map(_.stream).toSet, Set(a, b)))
+        _    <- IO(assert(resp.revisions.forall(_.revision == 0L), s"expected revision 0 on both: $resp"))
+        res  <- explained(stub.appendRecords(bad)).attempt
+        _    <- IO(assert(res.isLeft, s"expected consistency violation, got $res"))
+        _    <- IO(res match
+                  case Left(e: StatusRuntimeException) =>
+                    // The structured details from a real server must convert.
+                    grpc.convertV2.convertToEs(e) match
+                      case Some(v: exceptions.AppendConsistencyViolation) =>
+                        assertEquals(v.violations.map(_.streamId), List(a))
+                        assertEquals(v.violations.map(_.actual), List(0L))
+                      case other => fail(s"expected AppendConsistencyViolation from convertV2, got $other")
+                  case other => fail(s"expected StatusRuntimeException, got $other"))
+        _    <- res.swap.toOption.traverse_ {
+                  case e: StatusRuntimeException =>
+                    // Text-only descriptions would force parsing messages; structured
+                    // details (google.rpc.Status in the standard trailer) enable typed exceptions.
+                    val key     = Metadata.Key.of("grpc-status-details-bin", Metadata.BINARY_BYTE_MARSHALLER)
+                    val details = Option(e.getTrailers)
+                      .flatMap(t => Option(t.get(key)))
+                      .map(bytes => com.google.rpc.Status.parseFrom(bytes).details.map(_.typeUrl).mkString(", "))
+                    IO.println(s"[v2] conflict: ${e.getStatus.getCode}: ${e.getStatus.getDescription}") *>
+                      IO.println(s"[v2] structured details: ${details.getOrElse("<none in trailers>")}")
+                  case t =>
+                    IO.println(s"[v2] conflict error shape: ${t.getClass.getName}: ${t.getMessage}")
+                }
+        cRes <- client.streams
+                  .readStream(cId, StreamPosition.Start, Direction.Forwards, 10L, resolveLinkTos = false)
+                  .compile
+                  .toList
+                  .attempt
+        _    <- IO(cRes match
+                  case Left(_: StreamNotFound) => ()
+                  case other                   => fail(s"atomicity violated: stream $c should not exist, got $other"))
+      yield ()
+    }
+  }

--- a/tests/src/sit/scala/sec/api/streams/multiStreamAppend.scala
+++ b/tests/src/sit/scala/sec/api/streams/multiStreamAppend.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+import java.util.UUID
+import cats.data.NonEmptyList
+import cats.effect.IO
+import scodec.bits.ByteVector
+
+/** Complements the fit coverage, which runs insecure: this exercises multiStreamAppend on the
+  * TLS + credentials path, so the v2 stub's Context handling (auth, authority) is verified too.
+  */
+class MultiStreamAppendSuite extends SnSuite:
+
+  test("multiStreamAppend over TLS roundtrips and raises typed exceptions") {
+
+    val aId = genStreamId("sit_msa_a_")
+    val bId = genStreamId("sit_msa_b_")
+
+    def rec = RecordData(
+      UUID.randomUUID(),
+      Schema.json("sit-msa-event"),
+      ByteVector.view("{}".getBytes("UTF-8")),
+      Properties.empty
+    )
+
+    val appends = NonEmptyList.of(
+      StreamAppend(aId, StreamState.NoStream, NonEmptyList.one(rec)),
+      StreamAppend(bId, StreamState.NoStream, NonEmptyList.of(rec, rec))
+    )
+
+    for
+      r    <- client.streams.multiStreamAppend(appends)
+      _    <- IO(assert(
+                r.revisions.toList.toMap == Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L)),
+                s"unexpected revisions: ${r.revisions}"
+              ))
+      read <- client.streams
+                .readStream(aId, StreamPosition.Start, Direction.Forwards, 10L, resolveLinkTos = false)
+                .compile
+                .toList
+      _    <- IO(assertEquals(read.map(_.record.eventData.eventType.stringValue), List("sit-msa-event")))
+      // Single-record transaction: the event's log position must equal the reported transaction
+      // position, verifying the commit == prepare mapping of the v2 single-position response.
+      cId  = genStreamId("sit_msa_c_")
+      rc  <- client.streams.multiStreamAppend(NonEmptyList.one(
+               StreamAppend(cId, StreamState.NoStream, NonEmptyList.one(rec))
+             ))
+      cEv <- client.streams
+               .readStream(cId, StreamPosition.Start, Direction.Forwards, 1L, resolveLinkTos = false)
+               .compile
+               .lastOrError
+      _   <- IO(assertEquals(cEv.record.logPosition, rc.position))
+      bad   = NonEmptyList.one(StreamAppend(aId, StreamState.NoStream, NonEmptyList.one(rec)))
+      res  <- client.streams.multiStreamAppend(bad).attempt
+      _    <- IO(res match
+                case Left(v: exceptions.AppendConsistencyViolation) =>
+                  assertEquals(v.violations.map(_.streamId), List(aId.stringValue))
+                case other => fail(s"expected AppendConsistencyViolation, got $other"))
+    yield ()
+  }

--- a/tests/src/test/scala/sec/api/grpc/convertV2.scala
+++ b/tests/src/test/scala/sec/api/grpc/convertV2.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+package grpc
+
+import com.google.protobuf.any.Any as PbAny
+import com.google.rpc.Status as PbStatus
+import io.grpc.{Metadata, Status, StatusRuntimeException}
+import io.kurrentdb.protocol.v2.streams.errors as v2e
+import sec.api.exceptions.*
+
+class ConvertV2Suite extends SecSuite:
+
+  private val detailsKey: Metadata.Key[Array[Byte]] =
+    Metadata.Key.of("grpc-status-details-bin", Metadata.BINARY_BYTE_MARSHALLER)
+
+  private def sre(details: PbAny*): StatusRuntimeException =
+    val md = new Metadata()
+    md.put(detailsKey, PbStatus(code = com.google.rpc.Code.FAILED_PRECONDITION, details = details.headOption).toByteArray)
+    new StatusRuntimeException(Status.FAILED_PRECONDITION, md)
+
+  test("consistency violation details map to AppendConsistencyViolation with per-stream info") {
+    val d = v2e.AppendConsistencyViolationErrorDetails(violations =
+      Seq(
+        v2e.ConsistencyViolation(
+          checkIndex = 1,
+          `type`     = v2e.ConsistencyViolation.Type.StreamState(
+            v2e.ConsistencyViolation.StreamStateViolation(stream = "s1", expectedState = -1L, actualState = 0L)
+          )
+        )
+      )
+    )
+    assertEquals(
+      convertV2.convertToEs(sre(PbAny.pack(d))),
+      Some(AppendConsistencyViolation(List(AppendConsistencyViolation.StreamStateViolation("s1", -1L, 0L))))
+    )
+  }
+
+  test("revision conflict, size exceeded and stream lifecycle details map to their exceptions") {
+    val cases: List[(PbAny, EsException)] = List(
+      PbAny.pack(v2e.StreamRevisionConflictErrorDetails("s", 3L, 5L)) -> StreamRevisionConflict("s", 3L, 5L),
+      PbAny.pack(v2e.AppendRecordSizeExceededErrorDetails("s", "r", 10, 5)) ->
+        AppendRecordSizeExceeded("s", "r", 10, 5),
+      PbAny.pack(v2e.AppendTransactionSizeExceededErrorDetails(10, 5)) -> AppendTransactionSizeExceeded(10, 5),
+      PbAny.pack(v2e.StreamAlreadyExistsErrorDetails("s"))             -> StreamAlreadyExists("s"),
+      PbAny.pack(v2e.StreamTombstonedErrorDetails("s"))                -> StreamTombstoned("s"),
+      PbAny.pack(v2e.StreamDeletedErrorDetails("s"))                   -> StreamDeleted("s"),
+      PbAny.pack(v2e.StreamNotFoundErrorDetails("s"))                  -> StreamNotFound("s")
+    )
+    cases.foreach { case (any, expected) =>
+      assertEquals(convertV2.convertToEs(sre(any)), Some(expected), s"for ${any.typeUrl}")
+    }
+  }
+
+  test("unrecognized or absent details yield None") {
+    assertEquals(convertV2.convertToEs(sre()), None)
+    assertEquals(convertV2.convertToEs(new StatusRuntimeException(Status.FAILED_PRECONDITION)), None)
+    val foreign = PbAny.pack(v2e.StreamNotFoundErrorDetails("s")).copy(typeUrl = "type.googleapis.com/unknown.Type")
+    assertEquals(convertV2.convertToEs(sre(foreign)), None)
+  }

--- a/tests/src/test/scala/sec/api/mapping/streamsV2.scala
+++ b/tests/src/test/scala/sec/api/mapping/streamsV2.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+package mapping
+
+import java.util.UUID
+import cats.data.NonEmptyList
+import io.kurrentdb.protocol.v2.streams as pv2
+import scodec.bits.ByteVector
+import sec.arbitraries.*
+
+class StreamsV2MappingSuite extends SecSuite:
+
+  private def sid(prefix: String): StreamId.Id = sampleOfGen(idGen.genStreamIdNormal(prefix))
+
+  private def rec: RecordData =
+    RecordData(UUID.randomUUID(), Schema.json("t"), ByteVector.view("{}".getBytes("UTF-8")), Properties.empty)
+
+  test("expected state uses StreamState sentinel encoding") {
+    assertEquals(streamsV2.mkExpectedState(StreamState.NoStream), -1L)
+    assertEquals(streamsV2.mkExpectedState(StreamState.Any), -2L)
+    assertEquals(streamsV2.mkExpectedState(StreamState.StreamExists), -4L)
+    assertEquals(streamsV2.mkExpectedState(StreamPosition(7L)), 7L)
+  }
+
+  test("properties reject empty and reserved keys, accept valid ones") {
+    assert(Properties.of("$schema.name" -> PropertyValue.Str("x")).isLeft)
+    assert(Properties.of("" -> PropertyValue.Bool(true)).isLeft)
+    assert(Properties.of("tenant" -> PropertyValue.Str("acme"), "attempt" -> PropertyValue.Num(2)).isRight)
+  }
+
+  test("request couples one check to every written stream and appends guards after") {
+    val (a, b, g) = (sid("v2m_a_"), sid("v2m_b_"), sid("v2m_g_"))
+    val appends   = NonEmptyList.of(
+      StreamAppend(a, StreamState.NoStream, NonEmptyList.of(rec, rec)),
+      StreamAppend(b, StreamPosition(3L), NonEmptyList.one(rec))
+    )
+    val req = streamsV2.mkAppendRecordsRequest(appends, List(StreamGuard(g, StreamState.StreamExists)))
+
+    assertEquals(req.records.map(_.stream).toList, List(a, a, b).map(_.stringValue))
+    assertEquals(
+      req.checks.toList.flatMap(_.`type`.streamState).map(c => c.stream -> c.expectedState),
+      List(a.stringValue -> -1L, b.stringValue -> 3L, g.stringValue -> -4L)
+    )
+  }
+
+  test("result decoding recovers typed ids and rejects unknown streams") {
+    val a       = sid("v2m_r_")
+    val appends = NonEmptyList.one(StreamAppend(a, StreamState.NoStream, NonEmptyList.one(rec)))
+
+    type A[T] = Either[Throwable, T]
+
+    val ok = pv2.AppendRecordsResponse(position = 42L, revisions = Seq(pv2.StreamRevision(a.stringValue, 0L)))
+    assertEquals(
+      streamsV2.mkMultiAppendResult[A](appends)(ok),
+      Right(MultiAppendResult(LogPosition.exact(42L, 42L), NonEmptyList.one(a -> StreamPosition(0L))))
+    )
+
+    val unknown = pv2.AppendRecordsResponse(position = 42L, revisions = Seq(pv2.StreamRevision("other", 0L)))
+    assert(streamsV2.mkMultiAppendResult[A](appends)(unknown).isLeft)
+
+    val empty = pv2.AppendRecordsResponse(position = 42L, revisions = Seq.empty)
+    assert(streamsV2.mkMultiAppendResult[A](appends)(empty).isLeft)
+
+    val b        = sid("v2m_r2_")
+    val appends2 = appends :+ StreamAppend(b, StreamState.NoStream, NonEmptyList.one(rec))
+    val partial  = pv2.AppendRecordsResponse(position = 42L, revisions = Seq(pv2.StreamRevision(a.stringValue, 0L)))
+    assert(streamsV2.mkMultiAppendResult[A](appends2)(partial).isLeft, "partial responses must be rejected")
+  }


### PR DESCRIPTION
Adds experimental multiStreamAppend to the Streams API, backed by KurrentDB's v2 AppendRecords on the ops channel. The model makes the raw protocol's illegal states unrepresentable: StreamAppend couples a mandatory StreamState expectation to every written stream, and StreamGuard expresses consistency conditions on unwritten streams (dynamic consistency boundary). Records carry a schema (name surfaces as the v1 eventType) and validated properties rejecting the reserved dollar-prefixed namespace; the server synthesizes the v1 metadata view as JSON. Errors arrive as structured google.rpc.Status details and convert to typed exceptions (AppendConsistencyViolation with per-stream expected/actual, revision conflict, size limits) with fallback to the common v1 conversion. Verified end-to-end against a 26.1 node via the fit harness: v1 read roundtrip, atomicity, guard semantics, and typed error surfacing.