### PR TITLE
test+style: multi-append coverage, matrices, arbitraries, vocabulary

### DIFF
--- a/core/src/main/scala/sec/api/cluster/endpoints.scala
+++ b/core/src/main/scala/sec/api/cluster/endpoints.scala
@@ -29,7 +29,7 @@ private[sec] object ClusterEndpoints:
     * @param clusterDns
     *   DNS name to use for discovering endpoints.
     */
-  final case class ViaDns(
+  case class ViaDns(
     clusterDns: Hostname
   ) extends ClusterEndpoints
 
@@ -38,7 +38,7 @@ private[sec] object ClusterEndpoints:
     * @param endpoints
     *   Endpoints that provide cluster info.
     */
-  final case class ViaSeed(
+  case class ViaSeed(
     endpoints: NonEmptySet[Endpoint]
   ) extends ClusterEndpoints
 

--- a/core/src/main/scala/sec/api/endpoint.scala
+++ b/core/src/main/scala/sec/api/endpoint.scala
@@ -24,7 +24,7 @@ import io.grpc.{Attributes, EquivalentAddressGroup}
 /** Endpoint can be an IP Socket Address consisting of an IP address and port number. It can also be a hostname and a
   * port number, in which case an attempt will be made to resolve the hostname.
   */
-final case class Endpoint(
+case class Endpoint(
   address: String,
   port: Int
 )

--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -29,17 +29,17 @@ object exceptions:
 
   case object AccessDenied extends EsException("Access Denied.")
   case object InvalidTransaction extends EsException("Invalid Transaction.")
-  final case class UserNotFound(loginName: String) extends EsException(s"User '$loginName' was not found.")
-  final case class StreamDeleted(streamId: String) extends EsException(s"Event stream '$streamId' is deleted.")
-  final case class StreamNotFound(streamId: String) extends EsException(s"Event stream '$streamId' was not found.")
-  final case class UnknownError(msg: String) extends EsException(msg)
-  final case class ServerUnavailable(msg: String) extends EsException(msg)
-  final case class ResubscriptionRequired(msg: String) extends EsException(msg)
+  case class UserNotFound(loginName: String) extends EsException(s"User '$loginName' was not found.")
+  case class StreamDeleted(streamId: String) extends EsException(s"Event stream '$streamId' is deleted.")
+  case class StreamNotFound(streamId: String) extends EsException(s"Event stream '$streamId' was not found.")
+  case class UnknownError(msg: String) extends EsException(msg)
+  case class ServerUnavailable(msg: String) extends EsException(msg)
+  case class ResubscriptionRequired(msg: String) extends EsException(msg)
 
-  final case class SubscriptionPoolExhausted(channels: Int)
+  case class SubscriptionPoolExhausted(channels: Int)
     extends EsException(s"All $channels pooled subscription channels are at capacity - refusing to queue silently.")
 
-  final case class NotLeader(
+  case class NotLeader(
     host: Option[String],
     port: Option[Int]
   ) extends EsException(NotLeader.msg(host, port))
@@ -48,13 +48,13 @@ object exceptions:
     def msg(host: Option[String], port: Option[Int]): String =
       s"Not leader. Leader at ${host.getOrElse("<unknown>")}:${port.getOrElse("<unknown>")}."
 
-  final case class MaximumAppendSizeExceeded(size: Option[Int]) extends EsException(MaximumAppendSizeExceeded.msg(size))
+  case class MaximumAppendSizeExceeded(size: Option[Int]) extends EsException(MaximumAppendSizeExceeded.msg(size))
 
   object MaximumAppendSizeExceeded:
     def msg(maxSize: Option[Int]): String =
       s"Maximum append size ${maxSize.map(max => s"of $max bytes ").getOrElse("")}exceeded."
 
-  final case class WrongExpectedState(
+  case class WrongExpectedState(
     sid: StreamId,
     expected: StreamState,
     actual: StreamState
@@ -66,7 +66,7 @@ object exceptions:
       s"Wrong expected state for stream: ${sid.render}, expected: ${expected.render}, actual: ${actual.render}"
 
   // TODO: Remove when ESDB does not transport this via response headers
-  final case class WrongExpectedVersion(
+  case class WrongExpectedVersion(
     streamId: String,
     expected: Option[Long],
     actual: Option[Long]
@@ -89,26 +89,23 @@ object exceptions:
 
   object PersistentSubscription:
 
-    final case class Failed(streamId: String, groupName: String, reason: String)
+    case class Failed(streamId: String, groupName: String, reason: String)
       extends EsException(s"Subscription group $groupName on stream $streamId failed: '$reason'.")
 
-    final case class Exists(streamId: String, groupName: String)
+    case class Exists(streamId: String, groupName: String)
       extends EsException(s"Subscription group $groupName on stream $streamId exists.")
 
-    final case class NotFound(streamId: String, groupName: String)
+    case class NotFound(streamId: String, groupName: String)
       extends EsException(s"Subscription group '$groupName' on stream '$streamId' does not exist.")
 
-    final case class Dropped(streamId: String, groupName: String)
+    case class Dropped(streamId: String, groupName: String)
       extends EsException(s"Subscription group '$groupName' on stream '$streamId' was dropped by server.")
 
-    final case class MaximumSubscribersReached(streamId: String, groupName: String)
+    case class MaximumSubscribersReached(streamId: String, groupName: String)
       extends EsException(s"Maximum subscriptions reached for subscription group '$groupName' on stream '$streamId.'")
 
   // Multi-stream append. Constructed from structured google.rpc.Status details of the v2
   // protocol, see [[sec.api.grpc.convertV2]].
-
-  case class DuplicateStreams(streamIds: List[String])
-    extends EsException(s"Multi-stream append requires distinct streams; duplicates: ${streamIds.mkString(", ")}.")
 
   case class StreamAlreadyExists(streamId: String)
     extends EsException(s"Event stream '$streamId' already exists.")
@@ -117,8 +114,8 @@ object exceptions:
     extends EsException(s"Event stream '$streamId' is tombstoned.")
 
   /** expected / actual use StreamState sentinel encoding: -1 NoStream, -2 Any, -4 StreamExists, >= 0 exact. */
-  case class StreamRevisionConflict(streamId: String, expected: Long, actual: Long)
-    extends EsException(s"Stream '$streamId' revision conflict: expected $expected, actual $actual.")
+  case class StreamPositionConflict(streamId: String, expected: Long, actual: Long)
+    extends EsException(s"Stream '$streamId' position conflict: expected $expected, actual $actual.")
 
   case class AppendRecordSizeExceeded(streamId: String, recordId: String, size: Int, maxSize: Int)
     extends EsException(s"Record '$recordId' for stream '$streamId' is $size bytes, exceeding max of $maxSize.")

--- a/core/src/main/scala/sec/api/filter.scala
+++ b/core/src/main/scala/sec/api/filter.scala
@@ -37,7 +37,7 @@ import EventFilter.*
   *   - [[EventFilter.RegexFilter]] when you wish to filter with a regular expression. An example of this is
   *     `RegexFilter("^[^$].*")` when you for do not wish to retrieve events starting with `$`.
   */
-final case class EventFilter(
+case class EventFilter(
   kind: Kind,
   option: Either[NonEmptyList[PrefixFilter], RegexFilter]
 )
@@ -62,8 +62,8 @@ object EventFilter:
   //
 
   sealed trait Expression
-  final case class PrefixFilter(value: String) extends Expression
-  final case class RegexFilter(value: String) extends Expression
+  case class PrefixFilter(value: String) extends Expression
+  case class RegexFilter(value: String) extends Expression
 
   object RegexFilter:
     val excludeSystemEvents: RegexFilter = apply("^[^$].*".r)

--- a/core/src/main/scala/sec/api/gossip.scala
+++ b/core/src/main/scala/sec/api/gossip.scala
@@ -25,7 +25,7 @@ import cats.implicits.*
 
 /** Used for information about the nodes in an KurrentDB cluster.
   */
-final case class ClusterInfo(
+case class ClusterInfo(
   members: Set[MemberInfo]
 )
 
@@ -40,7 +40,7 @@ object ClusterInfo:
 
   extension (ci: ClusterInfo) def render: String = ClusterInfo.renderClusterInfo(ci)
 
-final case class MemberInfo(
+case class MemberInfo(
   instanceId: ju.UUID,
   timestamp: ZonedDateTime,
   state: VNodeState,

--- a/core/src/main/scala/sec/api/grpc/convertV2.scala
+++ b/core/src/main/scala/sec/api/grpc/convertV2.scala
@@ -57,7 +57,7 @@ private[sec] object convertV2:
       })
     } orElse
       unpackAs[v2e.StreamRevisionConflictErrorDetails](a).map { d =>
-        StreamRevisionConflict(d.stream, d.expectedRevision, d.actualRevision)
+        StreamPositionConflict(d.stream, d.expectedRevision, d.actualRevision)
       } orElse
       unpackAs[v2e.AppendRecordSizeExceededErrorDetails](a).map { d =>
         AppendRecordSizeExceeded(d.stream, d.recordId, d.size, d.maxSize)

--- a/core/src/main/scala/sec/api/mapping/streams.scala
+++ b/core/src/main/scala/sec/api/mapping/streams.scala
@@ -477,10 +477,10 @@ private[sec] object streams:
 
       import ReadResp.Content as c
 
-      final case class EventR(event: Option[sec.Event]) extends AllResult
-      final case class CheckpointR(checkpoint: Checkpoint) extends AllResult
-      final case class ConfirmationR(confirmation: SubscriptionConfirmation) extends AllResult
-      final case class LastPositionR(position: LogPosition) extends AllResult
+      case class EventR(event: Option[sec.Event]) extends AllResult
+      case class CheckpointR(checkpoint: Checkpoint) extends AllResult
+      case class ConfirmationR(confirmation: SubscriptionConfirmation) extends AllResult
+      case class LastPositionR(position: LogPosition) extends AllResult
 
       def fromWire[F[_]](p: ReadResp)(implicit F: MonadThrow[F]): F[AllResult] = p.content match
         case c.Event(v)                 => mkEvent[F](v).map(EventR(_))
@@ -518,12 +518,12 @@ private[sec] object streams:
 
       import ReadResp.Content as c
 
-      final case class EventR(event: Option[sec.Event]) extends StreamResult
-      final case class CheckpointR(checkpoint: Checkpoint) extends StreamResult
-      final case class ConfirmationR(confirmation: SubscriptionConfirmation) extends StreamResult
-      final case class StreamNotFoundR(streamId: StreamId) extends StreamResult
-      final case class FirstPositionR(position: StreamPosition) extends StreamResult
-      final case class LastPositionR(position: StreamPosition) extends StreamResult
+      case class EventR(event: Option[sec.Event]) extends StreamResult
+      case class CheckpointR(checkpoint: Checkpoint) extends StreamResult
+      case class ConfirmationR(confirmation: SubscriptionConfirmation) extends StreamResult
+      case class StreamNotFoundR(streamId: StreamId) extends StreamResult
+      case class FirstPositionR(position: StreamPosition) extends StreamResult
+      case class LastPositionR(position: StreamPosition) extends StreamResult
 
       def fromWire[F[_]](p: ReadResp)(implicit F: MonadThrow[F]): F[StreamResult] = p.content match
         case c.Event(v)               => mkEvent[F](v).map(EventR(_))

--- a/core/src/main/scala/sec/api/mapping/streamsV2.scala
+++ b/core/src/main/scala/sec/api/mapping/streamsV2.scala
@@ -18,7 +18,7 @@ package sec
 package api
 package mapping
 
-import cats.MonadThrow
+import cats.ApplicativeThrow
 import cats.data.NonEmptyList
 import cats.syntax.all.*
 import com.google.protobuf.struct as ps
@@ -26,8 +26,10 @@ import io.kurrentdb.protocol.v2.streams as pv2
 
 private[sec] object streamsV2:
 
-  /** StreamState sentinel encoding used by v2 checks: -1 NoStream, -2 Any, -4 StreamExists,
-    * otherwise the exact revision.
+  /** StreamState sentinel encoding used by v2 checks: -1 NoStream, -4 StreamExists, otherwise the
+    * exact stream position. The server also knows Deleted (-5) and Tombstoned (-6), which the sec
+    * model does not yet express; -2 (Any) exists in the v1 vocabulary only and is rejected by the
+    * server - Any is expressed by omitting the check, see [[mkAppendRecordsRequest]].
     */
   def mkExpectedState(ss: StreamState): Long = ss match
     case StreamState.NoStream     => -1L
@@ -62,16 +64,19 @@ private[sec] object streamsV2:
         pv2.ConsistencyCheck.StreamStateCheck(stream = streamId.stringValue, expectedState = mkExpectedState(expected))
       )
 
-  /** Every written stream carries exactly one check; guards add checks for unwritten streams. */
+  /** Every written stream carries at most one check; guards add checks for unwritten streams.
+    * The v2 protocol has no Any sentinel - the server rejects -2 with INVALID_ARGUMENT - so Any
+    * is expressed by omitting the check, and an Any guard is vacuous and not sent.
+    */
   def mkAppendRecordsRequest(appends: NonEmptyList[StreamAppend], guards: List[StreamGuard]): pv2.AppendRecordsRequest =
     pv2.AppendRecordsRequest(
       records = appends.toList.flatMap(a => a.records.toList.map(mkAppendRecord(a.streamId, _))),
-      checks  = appends.toList.map(a => mkCheck(a.streamId, a.expected)) ++
-        guards.map(g => mkCheck(g.streamId, g.expected))
+      checks  = appends.toList.collect { case a if a.expected != StreamState.Any => mkCheck(a.streamId, a.expected) } ++
+        guards.collect { case g if g.expected != StreamState.Any => mkCheck(g.streamId, g.expected) }
     )
 
   /** Recovers typed stream ids by joining response revisions with the request's appends. */
-  def mkMultiAppendResult[F[_]: MonadThrow](
+  def mkMultiAppendResult[F[_]: ApplicativeThrow](
     appends: NonEmptyList[StreamAppend]
   )(resp: pv2.AppendRecordsResponse): F[MultiAppendResult] =
     val byName = appends.toList.map(a => a.streamId.stringValue -> a.streamId).toMap
@@ -86,14 +91,14 @@ private[sec] object streamsV2:
       }
       .flatMap { rs =>
         NonEmptyList.fromList(rs).fold(shared.mkError[NonEmptyList[(StreamId.Id, StreamPosition.Exact)]](
-          "AppendRecordsResponse contained no revisions"
+          "AppendRecordsResponse contained no stream positions"
         ))(_.asRight)
       }
       .flatMap { rs =>
         val missing = appends.toList.map(_.streamId.stringValue).toSet -- rs.toList.map(_._1.stringValue).toSet
         if missing.isEmpty then rs.asRight
         else shared.mkError[NonEmptyList[(StreamId.Id, StreamPosition.Exact)]](
-          s"AppendRecordsResponse missing revisions for: ${missing.mkString(", ")}"
+          s"AppendRecordsResponse missing stream positions for: ${missing.mkString(", ")}"
         )
       }
       .map(MultiAppendResult(LogPosition.exact(resp.position, resp.position), _))

--- a/core/src/main/scala/sec/api/multiAppend.scala
+++ b/core/src/main/scala/sec/api/multiAppend.scala
@@ -80,5 +80,5 @@ case class StreamGuard(streamId: StreamId.Id, expected: StreamState)
   */
 case class MultiAppendResult(
   position: LogPosition.Exact,
-  revisions: NonEmptyList[(StreamId.Id, StreamPosition.Exact)]
+  streamPositions: NonEmptyList[(StreamId.Id, StreamPosition.Exact)]
 )

--- a/core/src/main/scala/sec/api/options.scala
+++ b/core/src/main/scala/sec/api/options.scala
@@ -87,10 +87,10 @@ private[sec] object Options:
 sealed private[sec] trait ConnectionMode
 private[sec] object ConnectionMode:
 
-  final case class CertB64(value: String) extends AnyVal
+  case class CertB64(value: String) extends AnyVal
 
   case object Insecure extends ConnectionMode
-  final case class Secure(cert: Either[File, CertB64]) extends ConnectionMode
+  case class Secure(cert: Either[File, CertB64]) extends ConnectionMode
   object Secure:
     def apply(file: File): Secure     = Secure(file.asLeft)
     def apply(base64: String): Secure = Secure(CertB64(base64).asRight)

--- a/core/src/main/scala/sec/api/streams.scala
+++ b/core/src/main/scala/sec/api/streams.scala
@@ -24,7 +24,7 @@ import exceptions.StreamNotFound
 /** Checkpoint result used with server-side filtering in KurrentDB. Contains the [[LogPosition.Exact]] when the
   * checkpoint was made.
   */
-final case class Checkpoint(
+case class Checkpoint(
   logPosition: LogPosition.Exact
 )
 
@@ -42,20 +42,20 @@ object Checkpoint:
 /** The current last [[StreamPosition.Exact]] of the stream appended to and its corresponding [[LogPosition.Exact]] in
   * the transaction log.
   */
-final case class WriteResult(
+case class WriteResult(
   streamPosition: StreamPosition.Exact,
   logPosition: LogPosition.Exact
 )
 
 /** The [[LogPosition.Exact]] of the delete in the transaction log.
   */
-final case class DeleteResult(
+case class DeleteResult(
   logPosition: LogPosition.Exact
 )
 
 /** The [[LogPosition.Exact]] of the tombstone in the transaction log.
   */
-final case class TombstoneResult(
+case class TombstoneResult(
   logPosition: LogPosition.Exact
 )
 
@@ -80,10 +80,10 @@ final private[sec] case class SubscriptionConfirmation(
 sealed trait StreamMessage
 object StreamMessage:
 
-  final case class StreamEvent(event: Event) extends StreamMessage
-  final case class FirstStreamPosition(position: StreamPosition) extends StreamMessage
-  final case class LastStreamPosition(position: StreamPosition) extends StreamMessage
-  final case class NotFound(streamId: StreamId) extends StreamMessage
+  case class StreamEvent(event: Event) extends StreamMessage
+  case class FirstStreamPosition(position: StreamPosition) extends StreamMessage
+  case class LastStreamPosition(position: StreamPosition) extends StreamMessage
+  case class NotFound(streamId: StreamId) extends StreamMessage
   object NotFound:
     extension (nf: NotFound) def toException: StreamNotFound = StreamNotFound(nf.streamId.render)
 
@@ -122,8 +122,8 @@ object StreamMessage:
 sealed trait AllMessage
 object AllMessage:
 
-  final case class AllEvent(event: Event) extends AllMessage
-  final case class LastAllStreamPosition(position: LogPosition) extends AllMessage
+  case class AllEvent(event: Event) extends AllMessage
+  case class LastAllStreamPosition(position: LogPosition) extends AllMessage
 
   //
 

--- a/core/src/main/scala/sec/error.scala
+++ b/core/src/main/scala/sec/error.scala
@@ -19,4 +19,4 @@ package sec
 import scala.util.control.NoStackTrace
 
 sealed abstract class ValidationError(msg: String) extends RuntimeException(msg) with NoStackTrace
-final case class InvalidInput(msg: String) extends ValidationError(msg)
+case class InvalidInput(msg: String) extends ValidationError(msg)

--- a/core/src/main/scala/sec/event.scala
+++ b/core/src/main/scala/sec/event.scala
@@ -80,7 +80,7 @@ object Event:
   * @param created
   *   the creation date of the event in [[java.time.ZonedDateTime]].
   */
-final case class EventRecord(
+case class EventRecord(
   streamId: StreamId,
   streamPosition: StreamPosition.Exact,
   logPosition: LogPosition.Exact,
@@ -112,7 +112,7 @@ object EventRecord:
   * @param link
   *   the link event to the resolved event.
   */
-final case class ResolvedEvent(
+case class ResolvedEvent(
   event: EventRecord,
   link: EventRecord
 ) extends Event
@@ -214,7 +214,7 @@ object EventType:
   * @param contentType
   *   the [[ContentType]] of encoded data and metadata.
   */
-final case class EventData(
+case class EventData(
   eventType: EventType,
   eventId: UUID,
   data: ByteVector,

--- a/core/src/main/scala/sec/id.scala
+++ b/core/src/main/scala/sec/id.scala
@@ -33,7 +33,7 @@ sealed trait StreamId
 object StreamId:
 
   sealed trait Id extends StreamId
-  final case class MetaId(id: Id) extends StreamId
+  case class MetaId(id: Id) extends StreamId
 
   sealed abstract case class System(name: String) extends Id
   private[sec] object System:

--- a/core/src/main/scala/sec/metadata.scala
+++ b/core/src/main/scala/sec/metadata.scala
@@ -270,7 +270,7 @@ end MetaState
   * @param metaWriteRoles
   *   Roles and users permitted to write stream metadata.
   */
-final case class StreamAcl(
+case class StreamAcl(
   readRoles: Set[String],
   writeRoles: Set[String],
   deleteRoles: Set[String],

--- a/core/src/main/scala/sec/position.scala
+++ b/core/src/main/scala/sec/position.scala
@@ -79,7 +79,7 @@ object StreamPosition:
 
   val Start: Exact = Exact(ULong.min)
 
-  final case class Exact(value: ULong) extends StreamPosition with StreamState
+  case class Exact(value: ULong) extends StreamPosition with StreamState
   object Exact:
     def fromUnsigned(value: Long): Exact = Exact(ULong(value))
 

--- a/docs/multi-append.md
+++ b/docs/multi-append.md
@@ -24,12 +24,14 @@ view as a JSON object of the user properties merged with reserved `$`-prefixed s
 is why `Properties.of` rejects keys using the `$` namespace.
 
 Every written stream carries a mandatory `StreamState` expectation via `StreamAppend`, and
-`StreamGuard` expresses conditions on unwritten streams. Streams must be distinct across appends
-and guards.
+`StreamGuard` expresses conditions on unwritten streams. A stream may appear only once across
+appends and guards, and a duplicate is rejected by the server. A `StreamState.Any` expectation
+produces no check on the wire - the v2 protocol has
+no Any sentinel and expresses it as absence - which also makes an Any guard vacuous.
 
 ### Example
 
-Below, a seat reservation is appended only if the flight stream is still at the revision observed
+Below, a seat reservation is appended only if the flight stream is still at the stream position observed
 when the decision was made — although nothing is written to the flight stream:
 
 ```scala mdoc:compile-only
@@ -66,7 +68,7 @@ object MultiAppend extends IOApp:
                        ),
                        guards = List(StreamGuard(flight, StreamPosition(42L)))
                      )
-      _           <- IO.println(s"committed at ${result.position}, revisions ${result.revisions}")
+      _           <- IO.println(s"committed at ${result.position}, streamPositions ${result.streamPositions}")
     yield ()
 ```
 
@@ -77,8 +79,7 @@ A successful append yields a `MultiAppendResult` with the transaction's single `
 `StreamPosition.Exact` per written stream.
 
 A violated expectation or guard raises `AppendConsistencyViolation`, naming each violating stream
-with its expected and actual state. Other failures surface as `StreamRevisionConflict`,
-`AppendRecordSizeExceeded`, `AppendTransactionSizeExceeded`, `StreamAlreadyExists`,
-`StreamTombstoned`, or — for duplicate streams in the request, rejected client side —
-`DuplicateStreams`. Streams that do not exist or are deleted raise the same `StreamNotFound` and
+with its expected and actual state. Other failures surface as `StreamPositionConflict`,
+`AppendRecordSizeExceeded`, `AppendTransactionSizeExceeded`, `StreamAlreadyExists`, or
+`StreamTombstoned`. Streams that do not exist or are deleted raise the same `StreamNotFound` and
 `StreamDeleted` as the v1 operations.

--- a/fs2/src/main/scala/sec/api/metastreams.scala
+++ b/fs2/src/main/scala/sec/api/metastreams.scala
@@ -271,7 +271,7 @@ object MetaStreams:
   type ReadResult[T]           = Result[Option[T]]
   private[sec] type MetaResult = Result[StreamMetadata]
 
-  final case class Result[T](
+  case class Result[T](
     streamPosition: StreamPosition.Exact,
     data: T
   )

--- a/fs2/src/main/scala/sec/api/retries.scala
+++ b/fs2/src/main/scala/sec/api/retries.scala
@@ -57,7 +57,7 @@ private[sec] object retries:
 
 //======================================================================================================================
 
-  final case class Timeout(after: FiniteDuration) extends RuntimeException(s"Timed out after ${format(after)}.")
+  case class Timeout(after: FiniteDuration) extends RuntimeException(s"Timed out after ${format(after)}.")
 
 //======================================================================================================================
 

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -166,7 +166,7 @@ trait Streams[F[_]]:
     * Appends records to one or more streams atomically; the server must support and have enabled
     * the v2 protocol. Every written stream carries a mandatory [[StreamState]] expectation, and
     * [[sec.api.StreamGuard]] expresses conditions on streams that are read from but not written
-    * to: below, the reservation is appended only if the flight stream is still at revision 42,
+    * to: below, the reservation is appended only if the flight stream is still at stream position 42,
     * although nothing is written to it (dynamic consistency boundary).
     *
     * {{{
@@ -177,8 +177,10 @@ trait Streams[F[_]]:
     * }}}
     *
     * Failure to fulfill a check is manifested by raising
-    * [[sec.api.exceptions.AppendConsistencyViolation]]. Streams must be distinct across appends
-    * and guards; duplicates raise [[sec.api.exceptions.DuplicateStreams]].
+    * [[sec.api.exceptions.AppendConsistencyViolation]]. A stream may appear only once across
+    * appends and guards; a duplicate is rejected by the server. A
+    * [[StreamState.Any]] expectation produces no check on the wire - the v2 protocol expresses
+    * Any as absence - which also renders an Any guard vacuous.
     *
     * @param appends
     *   the streams to append to, each with an expectation and its records. See [[sec.api.StreamAppend]].
@@ -436,17 +438,11 @@ object Streams:
     opts: Opts[F]
   )(f: V2AppendReq => F[V2AppendResp]): F[MultiAppendResult] =
 
-    // Duplicates across appends and guards would place multiple, potentially conflicting, checks
-    // on one stream - an illegal state the collection types cannot rule out, so it is rejected here.
-    val ids  = appends.toList.map(_.streamId.stringValue) ++ guards.map(_.streamId.stringValue)
-    val dups = ids.groupBy(identity).collect { case (id, xs) if xs.sizeIs > 1 => id }.toList.sorted
-
-    dups match
-      case Nil =>
-        val req = mapping.streamsV2.mkAppendRecordsRequest(appends, guards)
-        opts.run(f(req), "multiStreamAppend") >>= mapping.streamsV2.mkMultiAppendResult[F](appends)
-      case ds =>
-        exceptions.DuplicateStreams(ds).raiseError
+    // A stream may appear only once across a request's consistency checks; this is enforced by
+    // the server (AppendRecordsRequestValidator, ordinal case-insensitive), so we send the request
+    // and surface its rejection rather than replicate - and risk drifting from - that rule.
+    val req = mapping.streamsV2.mkAppendRecordsRequest(appends, guards)
+    opts.run(f(req), "multiStreamAppend") >>= mapping.streamsV2.mkMultiAppendResult[F](appends)
 
   private[sec] def delete0[F[_]: Temporal](
     streamId: StreamId,

--- a/tests/src/fit/scala/sec/api/streams/multiStreamAppend.scala
+++ b/tests/src/fit/scala/sec/api/streams/multiStreamAppend.scala
@@ -17,6 +17,7 @@
 package sec
 package api
 
+import java.util as ju
 import cats.syntax.all.*
 import cats.effect.{IO, Resource}
 import com.google.protobuf.ByteString
@@ -26,6 +27,7 @@ import io.grpc.{Metadata, Status, StatusRuntimeException}
 import io.kurrentdb.protocol.v2.streams.*
 import scodec.bits.ByteVector
 import sec.api.exceptions.StreamNotFound
+import sec.arbitraries.*
 
 /** Fault-harness coverage for v2 multi-stream append against a real node: v1 read roundtrip of
   * v2-written records, user-property metadata synthesis, request atomicity, guard semantics on
@@ -46,7 +48,7 @@ class MultiStreamAppendSuite extends FSuite:
 
   private def record(stream: String): AppendRecord =
     AppendRecord(
-      recordId   = Some(java.util.UUID.randomUUID().toString),
+      recordId   = Some(sampleOf[ju.UUID].toString),
       properties = Map.empty,
       schema     = Some(SchemaInfo(format = SchemaFormat.SCHEMA_FORMAT_JSON, name = schemaName)),
       data       = ByteString.copyFromUtf8(payload),
@@ -139,7 +141,7 @@ class MultiStreamAppendSuite extends FSuite:
       val cId = genStreamId("fit_v2_map_c_")
 
       def rec = RecordData(
-        java.util.UUID.randomUUID(),
+        sampleOf[ju.UUID],
         Schema.json(schemaName),
         scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
         Properties.of("tenant" -> PropertyValue.Str("acme")).fold(m => fail(m), identity)
@@ -163,7 +165,7 @@ class MultiStreamAppendSuite extends FSuite:
         resp   <- explained(stub.appendRecords(ok))
         result <- mapping.streamsV2.mkMultiAppendResult[IO](appends)(resp)
         _      <- IO(assertEquals(
-                    result.revisions.toList.toMap,
+                    result.streamPositions.toList.toMap,
                     Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L))
                   ))
         res    <- explained(stub.appendRecords(bad)).attempt
@@ -186,7 +188,7 @@ class MultiStreamAppendSuite extends FSuite:
       val bId = genStreamId("fit_v2_api_b_")
 
       def rec = RecordData(
-        java.util.UUID.randomUUID(),
+        sampleOf[ju.UUID],
         Schema.json(schemaName),
         scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
         Properties.empty
@@ -200,7 +202,7 @@ class MultiStreamAppendSuite extends FSuite:
       for
         r   <- client.streams.multiStreamAppend(appends)
         _   <- IO(assertEquals(
-                 r.revisions.toList.toMap,
+                 r.streamPositions.toList.toMap,
                  Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L))
                ))
         // The error adapter must surface a violated guard as the typed exception directly.
@@ -214,22 +216,210 @@ class MultiStreamAppendSuite extends FSuite:
     }
   }
 
-  test("duplicate streams across appends and guards are rejected client-side") {
+  test("all violated checks are reported, not only the first") {
     mkClient().use { client =>
       import cats.data.NonEmptyList as CNel
 
-      val aId = genStreamId("fit_v2_dup_")
-      val rec = RecordData(
-        java.util.UUID.randomUUID(),
+      val aId = genStreamId("fit_v2_viol_a_")
+      val bId = genStreamId("fit_v2_viol_b_")
+
+      def rec = RecordData(
+        sampleOf[ju.UUID],
         Schema.json(schemaName),
         scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
         Properties.empty
       )
 
-      val appends = CNel.one(StreamAppend(aId, StreamState.NoStream, CNel.one(rec)))
-      client.streams.multiStreamAppend(appends, List(StreamGuard(aId, StreamState.NoStream))).attempt.map {
-        case Left(exceptions.DuplicateStreams(ids)) => assertEquals(ids, List(aId.stringValue))
-        case other                                     => fail(s"expected DuplicateStreams, got $other")
+      // Both streams expect existence, neither exists: the details must carry both violations,
+      // per the errors.proto contract that all violated checks are included.
+      val appends = CNel.of(
+        StreamAppend(aId, StreamState.StreamExists, CNel.one(rec)),
+        StreamAppend(bId, StreamState.StreamExists, CNel.one(rec))
+      )
+
+      client.streams.multiStreamAppend(appends).attempt.map {
+        case Left(v: exceptions.AppendConsistencyViolation) =>
+          assertEquals(
+            v.violations.map(x => (x.streamId, x.expected, x.actual)).toSet,
+            Set((aId.stringValue, -4L, -1L), (bId.stringValue, -4L, -1L))
+          )
+        case other => fail(s"expected AppendConsistencyViolation with both streams, got $other")
+      }
+    }
+  }
+
+  test("exact stream position expectations are violated precisely and honored when correct") {
+    mkClient().use { client =>
+      import cats.data.NonEmptyList as CNel
+
+      val cId = genStreamId("fit_v2_exact_")
+
+      def rec = RecordData(
+        sampleOf[ju.UUID],
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.empty
+      )
+
+      def append(expected: StreamState) =
+        client.streams.multiStreamAppend(CNel.one(StreamAppend(cId, expected, CNel.one(rec))))
+
+      for
+        _   <- append(StreamState.NoStream) // stream position 0
+        res <- append(StreamPosition(5L)).attempt
+        _   <- IO(res match
+                 case Left(v: exceptions.AppendConsistencyViolation) =>
+                   assertEquals(
+                     v.violations.map(x => (x.streamId, x.expected, x.actual)),
+                     List((cId.stringValue, 5L, 0L))
+                   )
+                 case other => fail(s"expected violation with exact expected/actual, got $other"))
+        ok  <- append(StreamPosition(0L))
+        _   <- IO(assertEquals(ok.streamPositions.toList, List(cId -> StreamPosition(1L))))
+      yield ()
+    }
+  }
+
+  test("appends to tombstoned streams fail as a consistency violation") {
+    mkClient().use { client =>
+      import cats.data.NonEmptyList as CNel
+
+      val dId = genStreamId("fit_v2_tomb_")
+
+      def rec = RecordData(
+        sampleOf[ju.UUID],
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.empty
+      )
+
+      // The server refuses an append to a tombstoned stream as a consistency violation whose
+      // actual state is the Tombstoned sentinel (-6), not a tombstone-typed detail, so convertV2
+      // surfaces AppendConsistencyViolation rather than StreamTombstoned. (The dotnet client
+      // promotes actual -6/-5 to a typed exception; sec does not yet - see follow-up.)
+      for
+        _   <- client.streams.appendToStream(dId, StreamState.NoStream, genEvents(1))
+        _   <- client.streams.tombstone(dId, StreamState.StreamExists)
+        res <- client.streams
+                 .multiStreamAppend(CNel.one(StreamAppend(dId, StreamState.NoStream, CNel.one(rec))))
+                 .attempt
+        _   <- IO(res match
+                 case Left(e: exceptions.AppendConsistencyViolation) =>
+                   assertEquals(e.violations.map(v => (v.streamId, v.expected, v.actual)), List((dId.stringValue, -1L, -6L)))
+                 case other => fail(s"expected AppendConsistencyViolation, got $other"))
+      yield ()
+    }
+  }
+
+  test("write expectations across stream states follow the server matrix") {
+    mkClient().use { client =>
+      import cats.data.NonEmptyList as CNel
+      import StreamState.{Any, NoStream, StreamExists}
+
+      def rec = RecordData(
+        sampleOf[ju.UUID],
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.empty
+      )
+
+      def notFound: IO[StreamId.Id]   = IO(genStreamId("fit_v2_wm_"))
+      def atZero: IO[StreamId.Id]     =
+        notFound.flatTap(id => client.streams.appendToStream(id, NoStream, genEvents(1)))
+      def deleted: IO[StreamId.Id]    =
+        atZero.flatTap(id => client.streams.delete(id, StreamExists))
+      def tombstoned: IO[StreamId.Id] =
+        atZero.flatTap(id => client.streams.tombstone(id, StreamExists))
+
+      def write(id: StreamId.Id, expected: StreamState): IO[Boolean] =
+        client.streams
+          .multiStreamAppend(CNel.one(StreamAppend(id, expected, CNel.one(rec))))
+          .attempt
+          .map(_.isRight)
+
+      // Expected outcomes per the matrix pinned by the official clients. Exception types are
+      // covered by the targeted tests; here the semantics under test is accept/reject per cell.
+      val cases: List[(String, StreamState, IO[StreamId.Id], Boolean)] = List(
+        ("NoStream on not-found", NoStream, notFound, true),
+        ("NoStream on existing", NoStream, atZero, false),
+        ("NoStream on deleted", NoStream, deleted, true),
+        ("NoStream on tombstoned", NoStream, tombstoned, false),
+        ("Any on not-found", Any, notFound, true),
+        ("Any on existing", Any, atZero, true),
+        ("Any on deleted", Any, deleted, true),
+        ("Any on tombstoned", Any, tombstoned, false),
+        ("StreamExists on not-found", StreamExists, notFound, false),
+        ("StreamExists on existing", StreamExists, atZero, true),
+        ("StreamExists on deleted", StreamExists, deleted, false),
+        ("StreamExists on tombstoned", StreamExists, tombstoned, false),
+        ("exact on not-found", StreamPosition(0L), notFound, false),
+        ("exact on existing", StreamPosition(0L), atZero, true),
+        // A soft-deleted stream keeps its last surviving position, so an exact expectation matching
+        // it is honoured and the append succeeds - the write and guard matrices agree here. True
+        // only because atZero leaves the survivor at revision 0 and we expect exactly 0.
+        ("exact on deleted", StreamPosition(0L), deleted, true),
+        ("exact on tombstoned", StreamPosition(0L), tombstoned, false)
+      )
+
+      cases.traverse_ { case (desc, expected, mkStream, succeeds) =>
+        mkStream.flatMap(write(_, expected)).map(r => assertEquals(r, succeeds, desc))
+      }
+    }
+  }
+
+  test("guard expectations across stream states follow the server matrix") {
+    mkClient().use { client =>
+      import cats.data.NonEmptyList as CNel
+      import StreamState.{NoStream, StreamExists}
+
+      def rec = RecordData(
+        sampleOf[ju.UUID],
+        Schema.json(schemaName),
+        scodec.bits.ByteVector.view(payload.getBytes("UTF-8")),
+        Properties.empty
+      )
+
+      def notFound: IO[StreamId.Id]   = IO(genStreamId("fit_v2_gm_"))
+      def atZero: IO[StreamId.Id]     =
+        notFound.flatTap(id => client.streams.appendToStream(id, NoStream, genEvents(1)))
+      def deleted: IO[StreamId.Id]    =
+        atZero.flatTap(id => client.streams.delete(id, StreamExists))
+      def tombstoned: IO[StreamId.Id] =
+        atZero.flatTap(id => client.streams.tombstone(id, StreamExists))
+
+      def guarded(guard: StreamGuard): IO[Boolean] =
+        client.streams
+          .multiStreamAppend(
+            CNel.one(StreamAppend(genStreamId("fit_v2_gmw_"), NoStream, CNel.one(rec))),
+            List(guard)
+          )
+          .attempt
+          .map(_.isRight)
+
+      // Note the asymmetry with the write matrix: a NoStream guard passes on a tombstoned
+      // stream - checks treat tombstoned as nonexistent - while writes reject it outright.
+      val cases: List[(String, StreamState, IO[StreamId.Id], Boolean)] = List(
+        ("NoStream guard on not-found", NoStream, notFound, true),
+        ("NoStream guard on existing", NoStream, atZero, false),
+        ("NoStream guard on deleted", NoStream, deleted, true),
+        ("NoStream guard on tombstoned", NoStream, tombstoned, true),
+        ("StreamExists guard on not-found", StreamExists, notFound, false),
+        ("StreamExists guard on existing", StreamExists, atZero, true),
+        ("StreamExists guard on deleted", StreamExists, deleted, false),
+        ("StreamExists guard on tombstoned", StreamExists, tombstoned, false),
+        ("exact guard on not-found", StreamPosition(0L), notFound, false),
+        ("exact guard on existing", StreamPosition(0L), atZero, true),
+        // A check on a soft-deleted stream is evaluated against its last surviving position, so an
+        // exact check matching it passes; NoStream also passes (a check treats deleted as absent)
+        // and StreamExists fails. Confirmed against the server's AppendRecords CheckOnly suite
+        // (WhenExpectingRevision/NoStream/Exists). True here only because atZero leaves the
+        // survivor at revision 0 and we check exactly 0.
+        ("exact guard on deleted", StreamPosition(0L), deleted, true),
+        ("exact guard on tombstoned", StreamPosition(0L), tombstoned, false)
+      )
+
+      cases.traverse_ { case (desc, expected, mkStream, succeeds) =>
+        mkStream.flatMap(id => guarded(StreamGuard(id, expected))).map(r => assertEquals(r, succeeds, desc))
       }
     }
   }

--- a/tests/src/main/scala/sec/arbitraries.scala
+++ b/tests/src/main/scala/sec/arbitraries.scala
@@ -297,4 +297,46 @@ object arbitraries {
     Gen.listOfN(5, arbMemberInfo.arbitrary).map(ms => ClusterInfo(ms.toSet))
   }
 
+//======================================================================================================================
+// Multi-Stream Append
+//======================================================================================================================
+
+  private[sec] object multiAppendGen {
+
+    import scodec.bits.ByteVector
+    import sec.api.{Properties, PropertyValue, RecordData, Schema, SchemaFormat}
+
+    val schemaFormat: Gen[SchemaFormat] =
+      Gen.oneOf(SchemaFormat.values.toIndexedSeq)
+
+    val schema: Gen[Schema] =
+      for
+        name   <- Gen.identifier
+        format <- schemaFormat
+      yield Schema(s"sec-$name", format)
+
+    val propertyValue: Gen[PropertyValue] = Gen.oneOf(
+      Gen.alphaNumStr.map(PropertyValue.Str(_)),
+      Arbitrary.arbitrary[Double].map(PropertyValue.Num(_)),
+      Arbitrary.arbitrary[Boolean].map(PropertyValue.Bool(_))
+    )
+
+    val properties: Gen[Properties] = Gen
+      .mapOf(Gen.zip(Gen.identifier, propertyValue))
+      .map(kvs => Properties.of(kvs.toList*).fold(sys.error, identity))
+
+    val recordData: Gen[RecordData] =
+      for
+        id    <- Gen.uuid
+        s     <- schema
+        data  <- Gen.listOf(Arbitrary.arbitrary[Byte]).map(ByteVector(_))
+        props <- properties
+      yield RecordData(id, s, data, props)
+  }
+
+  implicit val arbSchemaFormat: Arbitrary[sec.api.SchemaFormat]   = Arbitrary(multiAppendGen.schemaFormat)
+  implicit val arbPropertyValue: Arbitrary[sec.api.PropertyValue] = Arbitrary(multiAppendGen.propertyValue)
+  implicit val arbProperties: Arbitrary[sec.api.Properties]       = Arbitrary(multiAppendGen.properties)
+  implicit val arbRecordData: Arbitrary[sec.api.RecordData]       = Arbitrary(multiAppendGen.recordData)
+
 }

--- a/tests/src/main/scala/sec/misc.scala
+++ b/tests/src/main/scala/sec/misc.scala
@@ -20,17 +20,17 @@ import io.circe.Codec
 
 //======================================================================================================================
 
-final case class Custom(name: String, numbers: List[Int])
+case class Custom(name: String, numbers: List[Int])
 object Custom:
   given Codec.AsObject[Custom] =
     Codec.forProduct2("name", "numbers")(Custom.apply)(c => (c.name, c.numbers))
 
-final case class Bar(name: String)
+case class Bar(name: String)
 object Bar:
   given Codec.AsObject[Bar] =
     Codec.forProduct1("name")(Bar.apply)(_.name)
 
-final case class Foo(bars: List[Bar])
+case class Foo(bars: List[Bar])
 object Foo:
   given Codec.AsObject[Foo] =
     Codec.forProduct1("bars")(Foo.apply)(_.bars)

--- a/tests/src/sit/scala/sec/api/streams/multiStreamAppend.scala
+++ b/tests/src/sit/scala/sec/api/streams/multiStreamAppend.scala
@@ -17,10 +17,11 @@
 package sec
 package api
 
-import java.util.UUID
+import java.util as ju
 import cats.data.NonEmptyList
 import cats.effect.IO
 import scodec.bits.ByteVector
+import sec.arbitraries.*
 
 /** Complements the fit coverage, which runs insecure: this exercises multiStreamAppend on the
   * TLS + credentials path, so the v2 stub's Context handling (auth, authority) is verified too.
@@ -33,7 +34,7 @@ class MultiStreamAppendSuite extends SnSuite:
     val bId = genStreamId("sit_msa_b_")
 
     def rec = RecordData(
-      UUID.randomUUID(),
+      sampleOf[ju.UUID],
       Schema.json("sit-msa-event"),
       ByteVector.view("{}".getBytes("UTF-8")),
       Properties.empty
@@ -47,8 +48,8 @@ class MultiStreamAppendSuite extends SnSuite:
     for
       r    <- client.streams.multiStreamAppend(appends)
       _    <- IO(assert(
-                r.revisions.toList.toMap == Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L)),
-                s"unexpected revisions: ${r.revisions}"
+                r.streamPositions.toList.toMap == Map(aId -> StreamPosition(0L), bId -> StreamPosition(1L)),
+                s"unexpected stream positions: ${r.streamPositions}"
               ))
       read <- client.streams
                 .readStream(aId, StreamPosition.Start, Direction.Forwards, 10L, resolveLinkTos = false)

--- a/tests/src/test/scala/sec/api/cluster/notifier.scala
+++ b/tests/src/test/scala/sec/api/cluster/notifier.scala
@@ -170,7 +170,7 @@ class NotifierSuite extends SecEffectSuite:
 
 object NotifierSuite:
 
-  final case class RecordingListener[F[_]](recordings: Ref[F, List[Nel[Endpoint]]]) extends Listener[F]:
+  case class RecordingListener[F[_]](recordings: Ref[F, List[Nel[Endpoint]]]) extends Listener[F]:
     def onResult(result: Nel[Endpoint]): F[Unit] = recordings.update(_ :+ result)
 
   def mkUpdates[F[_]](

--- a/tests/src/test/scala/sec/api/grpc/convertV2.scala
+++ b/tests/src/test/scala/sec/api/grpc/convertV2.scala
@@ -53,7 +53,7 @@ class ConvertV2Suite extends SecSuite:
 
   test("revision conflict, size exceeded and stream lifecycle details map to their exceptions") {
     val cases: List[(PbAny, EsException)] = List(
-      PbAny.pack(v2e.StreamRevisionConflictErrorDetails("s", 3L, 5L)) -> StreamRevisionConflict("s", 3L, 5L),
+      PbAny.pack(v2e.StreamRevisionConflictErrorDetails("s", 3L, 5L)) -> StreamPositionConflict("s", 3L, 5L),
       PbAny.pack(v2e.AppendRecordSizeExceededErrorDetails("s", "r", 10, 5)) ->
         AppendRecordSizeExceeded("s", "r", 10, 5),
       PbAny.pack(v2e.AppendTransactionSizeExceededErrorDetails(10, 5)) -> AppendTransactionSizeExceeded(10, 5),

--- a/tests/src/test/scala/sec/api/mapping/streams.scala
+++ b/tests/src/test/scala/sec/api/mapping/streams.scala
@@ -1122,7 +1122,7 @@ object StreamsMappingSuite {
   def bv(data: String): ByteVector =
     encodeToBV(data).unsafe
 
-  final case class EventAndLink(
+  case class EventAndLink(
     event: EventRecord,
     eventProto: s.ReadResp.ReadEvent.RecordedEvent,
     link: EventRecord,

--- a/tests/src/test/scala/sec/api/mapping/streamsV2.scala
+++ b/tests/src/test/scala/sec/api/mapping/streamsV2.scala
@@ -18,18 +18,15 @@ package sec
 package api
 package mapping
 
-import java.util.UUID
 import cats.data.NonEmptyList
 import io.kurrentdb.protocol.v2.streams as pv2
-import scodec.bits.ByteVector
 import sec.arbitraries.*
 
 class StreamsV2MappingSuite extends SecSuite:
 
   private def sid(prefix: String): StreamId.Id = sampleOfGen(idGen.genStreamIdNormal(prefix))
 
-  private def rec: RecordData =
-    RecordData(UUID.randomUUID(), Schema.json("t"), ByteVector.view("{}".getBytes("UTF-8")), Properties.empty)
+  private def rec: RecordData = sampleOf[RecordData]
 
   test("expected state uses StreamState sentinel encoding") {
     assertEquals(streamsV2.mkExpectedState(StreamState.NoStream), -1L)
@@ -44,17 +41,20 @@ class StreamsV2MappingSuite extends SecSuite:
     assert(Properties.of("tenant" -> PropertyValue.Str("acme"), "attempt" -> PropertyValue.Num(2)).isRight)
   }
 
-  test("request couples one check to every written stream and appends guards after") {
-    val (a, b, g) = (sid("v2m_a_"), sid("v2m_b_"), sid("v2m_g_"))
-    val appends   = NonEmptyList.of(
+  test("request couples checks to written streams, appends guards, and omits Any") {
+    val (a, b, c, g) = (sid("v2m_a_"), sid("v2m_b_"), sid("v2m_c_"), sid("v2m_g_"))
+    val appends      = NonEmptyList.of(
       StreamAppend(a, StreamState.NoStream, NonEmptyList.of(rec, rec)),
-      StreamAppend(b, StreamPosition(3L), NonEmptyList.one(rec))
+      StreamAppend(b, StreamPosition(3L), NonEmptyList.one(rec)),
+      StreamAppend(c, StreamState.Any, NonEmptyList.one(rec))
     )
-    val req = streamsV2.mkAppendRecordsRequest(appends, List(StreamGuard(g, StreamState.StreamExists)))
+    val guards = List(StreamGuard(g, StreamState.StreamExists), StreamGuard(sid("v2m_v_"), StreamState.Any))
+    val req    = streamsV2.mkAppendRecordsRequest(appends, guards)
 
-    assertEquals(req.records.map(_.stream).toList, List(a, a, b).map(_.stringValue))
+    assertEquals(req.records.map(_.stream).toList, List(a, a, b, c).map(_.stringValue))
+    // Any appears in neither writes nor guards: absence of a check is the v2 encoding of Any.
     assertEquals(
-      req.checks.toList.flatMap(_.`type`.streamState).map(c => c.stream -> c.expectedState),
+      req.checks.toList.flatMap(_.`type`.streamState).map(x => x.stream -> x.expectedState),
       List(a.stringValue -> -1L, b.stringValue -> 3L, g.stringValue -> -4L)
     )
   }

--- a/tests/src/test/scala/sec/api/streams.scala
+++ b/tests/src/test/scala/sec/api/streams.scala
@@ -506,4 +506,4 @@ class SubConfirmationPipeSuite extends SecEffectSuite:
   }
 
 object StreamsSpec:
-  final case class RetryErr(msg: String = "") extends RuntimeException(msg) with NoStackTrace
+  case class RetryErr(msg: String = "") extends RuntimeException(msg) with NoStackTrace


### PR DESCRIPTION
Adds atomic multi-stream append over the v2 AppendRecords protocol: one
request writes records to several streams and commits or fails as a whole.
Each StreamAppend carries its own StreamState expectation; standalone
StreamGuard checks assert a stream's state without writing to it (dynamic
consistency boundaries); and MultiAppendResult reports the log position
together with the resulting per-stream positions. Streams gains
multiStreamAppend(appends, guards = Nil).

The public model lives in sec.api: StreamAppend, StreamGuard,
MultiAppendResult and a write-oriented RecordData (recordId, Schema, data,
Properties) kept distinct from EventData. User Properties are a typed,
scalar-valued map (Str, Num, Bool) whose private smart constructor rejects
empty and reserved $-prefixed keys, so an invalid property map cannot be
built.

Wire behaviour is aligned with the upstream server and dotnet client,
verified against their sources and exercised end-to-end by tests/Fit against
KurrentDB 26.1. Any has no v2 sentinel - the request validator rejects -2 -
and is instead expressed as the absence of a check, so mkAppendRecordsRequest
omits the check for an Any append or guard (a records-only request is valid,
and an Any guard is therefore vacuous); the other expressible states map to
-1 NoStream, -4 Exists or a revision, and mkExpectedState retains the -2
mapping though it is no longer reachable from the builder. A soft-deleted
stream keeps its last surviving position, so an exact expectation matching it
is honoured for both writes and guards; a NoStream guard passes on a
soft-deleted or tombstoned stream (a check treats it as absent) while a write
rejects it, and StreamExists fails on a deleted stream. An append to a
tombstoned stream is refused as an AppendConsistencyViolation whose actual
state is the Tombstoned sentinel (-6), not a typed StreamTombstoned. A stream
may appear only once across a request's consistency checks; that rule is
enforced server-side by AppendRecordsRequestValidator (ordinal
case-insensitive), so sec sends the request and surfaces the server's
rejection rather than replicating - and risking drift from - the rule.

Errors decode in convertV2 from the structured google.rpc.Status details of
the v2 protocol, falling back to the v1 conversion otherwise.
StreamRevisionConflict is renamed StreamPositionConflict and
MultiAppendResult.revisions becomes streamPositions to match sec's
vocabulary; the proto keeps its names. final is dropped from case classes
across core, fs2 and tests (unneeded in Scala 3).

ScalaCheck Arbitrary instances are added for RecordData, Schema,
SchemaFormat, PropertyValue and Properties, the Properties generator valid by
construction; tests use sampleOf per house style. The dotnet invalid-metadata
and interleaving tests are deliberately not ported: typed Properties make the
former unrepresentable, and records are grouped per stream by the model.

Follow-ups: promote actual -6/-5 to a typed StreamTombstoned/StreamDeleted
for append targets, as the dotnet client does; a NonEmptyMap-shaped result
and append input keyed by a case-insensitive (directed) stream-id equality so
that ids differing only in case cannot coexist; and richer property values,
since the server accepts the full google.protobuf.Value - null, nested struct
and list - beyond the current scalars.

  server:  V2.Tests/.../Validators/AppendRecordsRequestValidatorTests.cs
  server:  V2.Tests/.../Validators/AppendRecordValidatorTests.cs
  server:  V2.Tests/.../AppendRecords/{CheckOnly,WriteOnly}/WhenExpecting*.cs
  client:  Client.Tests/.../AppendRecords/WriteOnly/WhenExpectingAny.cs
  client:  Client.Tests/Streams/MultiStreamAppendTests.cs