### PR TITLE
refactor: drop multiStreamAppend default arg; remove Any-guard comments

### DIFF
--- a/core/src/main/scala/sec/api/mapping/streamsV2.scala
+++ b/core/src/main/scala/sec/api/mapping/streamsV2.scala
@@ -66,7 +66,7 @@ private[sec] object streamsV2:
 
   /** Every written stream carries at most one check; guards add checks for unwritten streams.
     * The v2 protocol has no Any sentinel - the server rejects -2 with INVALID_ARGUMENT - so Any
-    * is expressed by omitting the check, and an Any guard is vacuous and not sent.
+    * is expressed by omitting the check, for both appends and guards.
     */
   def mkAppendRecordsRequest(appends: NonEmptyList[StreamAppend], guards: List[StreamGuard]): pv2.AppendRecordsRequest =
     pv2.AppendRecordsRequest(

--- a/docs/multi-append.md
+++ b/docs/multi-append.md
@@ -27,7 +27,7 @@ Every written stream carries a mandatory `StreamState` expectation via `StreamAp
 `StreamGuard` expresses conditions on unwritten streams. A stream may appear only once across
 appends and guards, and a duplicate is rejected by the server. A `StreamState.Any` expectation
 produces no check on the wire - the v2 protocol has
-no Any sentinel and expresses it as absence - which also makes an Any guard vacuous.
+no Any sentinel and expresses it as absence.
 
 ### Example
 

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -180,7 +180,7 @@ trait Streams[F[_]]:
     * [[sec.api.exceptions.AppendConsistencyViolation]]. A stream may appear only once across
     * appends and guards; a duplicate is rejected by the server. A
     * [[StreamState.Any]] expectation produces no check on the wire - the v2 protocol expresses
-    * Any as absence - which also renders an Any guard vacuous.
+    * Any as absence.
     *
     * @param appends
     *   the streams to append to, each with an expectation and its records. See [[sec.api.StreamAppend]].
@@ -189,7 +189,7 @@ trait Streams[F[_]]:
     */
   def multiStreamAppend(
     appends: NonEmptyList[StreamAppend],
-    guards: List[StreamGuard] = Nil
+    guards: List[StreamGuard]
   ): F[MultiAppendResult]
 
   /** Deletes a stream and returns [[DeleteResult]] with current log position after a successful operation. Failure to
@@ -249,6 +249,10 @@ trait Streams[F[_]]:
   def messageReads: Reads[F]
 
 object Streams:
+
+  extension [F[_]](streams: Streams[F])
+    def multiStreamAppend(appends: NonEmptyList[StreamAppend]): F[MultiAppendResult] =
+      streams.multiStreamAppend(appends, Nil)
 
 //======================================================================================================================
 


### PR DESCRIPTION
Remove the guards default (Nil) - no default arguments in the public API; the no-guards call is provided as an extension instead. Drop the "an Any guard is vacuous" remark from the scaladoc, the streamsV2 comment and docs/multi-append.md.