### PR TITLE
feat: typed conditions for append consistency violations and mismatches

### DIFF
--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -113,9 +113,8 @@ object exceptions:
   case class StreamTombstoned(streamId: String)
     extends EsException(s"Event stream '$streamId' is tombstoned.")
 
-  /** expected / actual use StreamState sentinel encoding: -1 NoStream, -2 Any, -4 StreamExists, >= 0 exact. */
-  case class StreamPositionConflict(streamId: String, expected: Long, actual: Long)
-    extends EsException(s"Stream '$streamId' position conflict: expected $expected, actual $actual.")
+  case class StreamConditionMismatch(streamId: String, expected: ExpectedCondition, actual: ActualCondition)
+    extends EsException(s"Stream '$streamId' condition mismatch: expected ${expected.render}, actual ${actual.render}.")
 
   case class AppendRecordSizeExceeded(streamId: String, recordId: String, size: Int, maxSize: Int)
     extends EsException(s"Record '$recordId' for stream '$streamId' is $size bytes, exceeding max of $maxSize.")
@@ -123,14 +122,13 @@ object exceptions:
   case class AppendTransactionSizeExceeded(size: Int, maxSize: Int)
     extends EsException(s"Append transaction is $size bytes, exceeding max of $maxSize.")
 
-  case class AppendConsistencyViolation(violations: List[AppendConsistencyViolation.StreamStateViolation])
+  case class AppendConsistencyViolation(violations: List[AppendConsistencyViolation.StreamConditionViolation])
     extends EsException(AppendConsistencyViolation.mkMsg(violations))
 
   object AppendConsistencyViolation:
 
-    /** expected / actual use StreamState sentinel encoding: -1 NoStream, -2 Any, -4 StreamExists, >= 0 exact. */
-    case class StreamStateViolation(streamId: String, expected: Long, actual: Long)
+    case class StreamConditionViolation(streamId: String, expected: ExpectedCondition, actual: ActualCondition)
 
-    private[sec] def mkMsg(vs: List[StreamStateViolation]): String =
-      val detail = vs.map(v => s"'${v.streamId}' expected ${v.expected}, actual ${v.actual}").mkString("; ")
+    private[sec] def mkMsg(vs: List[StreamConditionViolation]): String =
+      val detail = vs.map(v => s"'${v.streamId}' expected ${v.expected.render}, actual ${v.actual.render}").mkString("; ")
       s"Append failed due to consistency violations: $detail."

--- a/core/src/main/scala/sec/api/grpc/convertV2.scala
+++ b/core/src/main/scala/sec/api/grpc/convertV2.scala
@@ -49,15 +49,20 @@ private[sec] object convertV2:
     if a.is[A] then Either.catchNonFatal(a.unpack[A]).toOption else None
 
   private def fromDetail(a: PbAny): Option[EsException] =
-    unpackAs[v2e.AppendConsistencyViolationErrorDetails](a).map { d =>
-      AppendConsistencyViolation(d.violations.toList.flatMap { cv =>
-        cv.`type`.streamState.map { ss =>
-          AppendConsistencyViolation.StreamStateViolation(ss.stream, ss.expectedState, ss.actualState)
+    unpackAs[v2e.AppendConsistencyViolationErrorDetails](a).flatMap { d =>
+      d.violations.toList
+        .flatMap(_.`type`.streamState)
+        .traverse { ss =>
+          (expectedCondition(ss.expectedState), actualCondition(ss.actualState)).mapN { (e, ac) =>
+            AppendConsistencyViolation.StreamConditionViolation(ss.stream, e, ac)
+          }
         }
-      })
+        .map(AppendConsistencyViolation(_))
     } orElse
-      unpackAs[v2e.StreamRevisionConflictErrorDetails](a).map { d =>
-        StreamPositionConflict(d.stream, d.expectedRevision, d.actualRevision)
+      unpackAs[v2e.StreamRevisionConflictErrorDetails](a).flatMap { d =>
+        (expectedCondition(d.expectedRevision), actualCondition(d.actualRevision)).mapN { (e, ac) =>
+          StreamConditionMismatch(d.stream, e, ac)
+        }
       } orElse
       unpackAs[v2e.AppendRecordSizeExceededErrorDetails](a).map { d =>
         AppendRecordSizeExceeded(d.stream, d.recordId, d.size, d.maxSize)
@@ -69,3 +74,18 @@ private[sec] object convertV2:
       unpackAs[v2e.StreamTombstonedErrorDetails](a).map(d => StreamTombstoned(d.stream)) orElse
       unpackAs[v2e.StreamDeletedErrorDetails](a).map(d => StreamDeleted(d.stream)) orElse
       unpackAs[v2e.StreamNotFoundErrorDetails](a).map(d => StreamNotFound(d.stream))
+
+  private def expectedCondition(v: Long): Option[ExpectedCondition] = v match
+    case -1          => ExpectedCondition.NoStream.some
+    case -4          => ExpectedCondition.StreamExists.some
+    case -5          => ExpectedCondition.SoftDeleted.some
+    case -6          => ExpectedCondition.Tombstoned.some
+    case n if n >= 0 => ExpectedCondition.AtPosition(StreamPosition(n)).some
+    case _           => none
+
+  private def actualCondition(v: Long): Option[ActualCondition] = v match
+    case -1          => ActualCondition.NotFound.some
+    case -5          => ActualCondition.SoftDeleted.some
+    case -6          => ActualCondition.Tombstoned.some
+    case n if n >= 0 => ActualCondition.AtPosition(StreamPosition(n)).some
+    case _           => none

--- a/core/src/main/scala/sec/api/streamCondition.scala
+++ b/core/src/main/scala/sec/api/streamCondition.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Scala Event Sourcing Client for KurrentDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sec
+package api
+
+/** The expected condition of a stream in a consistency check, echoed back in an
+  * [[sec.api.exceptions.AppendConsistencyViolation]]. Any is absent by design: it is expressed as
+  * the absence of a check and rejected as an explicit expected value.
+  */
+enum ExpectedCondition:
+  case NoStream, StreamExists, SoftDeleted, Tombstoned
+  case AtPosition(position: StreamPosition.Exact)
+
+  def render: String = this match
+    case NoStream        => "NoStream"
+    case StreamExists    => "StreamExists"
+    case SoftDeleted     => "SoftDeleted"
+    case Tombstoned      => "Tombstoned"
+    case AtPosition(p)   => s"position ${p.value.render}"
+
+/** The actual condition of a stream reported in an [[sec.api.exceptions.AppendConsistencyViolation]]. */
+enum ActualCondition:
+  case NotFound, SoftDeleted, Tombstoned
+  case AtPosition(position: StreamPosition.Exact)
+
+  def render: String = this match
+    case NotFound      => "NotFound"
+    case SoftDeleted   => "SoftDeleted"
+    case Tombstoned    => "Tombstoned"
+    case AtPosition(p) => s"position ${p.value.render}"

--- a/docs/multi-append.md
+++ b/docs/multi-append.md
@@ -79,7 +79,7 @@ A successful append yields a `MultiAppendResult` with the transaction's single `
 `StreamPosition.Exact` per written stream.
 
 A violated expectation or guard raises `AppendConsistencyViolation`, naming each violating stream
-with its expected and actual state. Other failures surface as `StreamPositionConflict`,
+with its expected and actual state. Other failures surface as `StreamConditionMismatch`,
 `AppendRecordSizeExceeded`, `AppendTransactionSizeExceeded`, `StreamAlreadyExists`, or
 `StreamTombstoned`. Streams that do not exist or are deleted raise the same `StreamNotFound` and
 `StreamDeleted` as the v1 operations.

--- a/fs2/src/main/scala/sec/api/streams.scala
+++ b/fs2/src/main/scala/sec/api/streams.scala
@@ -445,8 +445,22 @@ object Streams:
     // A stream may appear only once across a request's consistency checks; this is enforced by
     // the server (AppendRecordsRequestValidator, ordinal case-insensitive), so we send the request
     // and surface its rejection rather than replicate - and risk drifting from - that rule.
-    val req = mapping.streamsV2.mkAppendRecordsRequest(appends, guards)
-    opts.run(f(req), "multiStreamAppend") >>= mapping.streamsV2.mkMultiAppendResult[F](appends)
+    val targets = appends.toList.map(_.streamId.stringValue).toSet
+    val req     = mapping.streamsV2.mkAppendRecordsRequest(appends, guards)
+
+    // A tombstoned or soft-deleted append target surfaces as a consistency violation; promote it to
+    // the corresponding typed exception, scoped to append targets (a guard keeps the violation).
+    (opts.run(f(req), "multiStreamAppend") >>= mapping.streamsV2.mkMultiAppendResult[F](appends))
+      .adaptError {
+        case exceptions.AppendConsistencyViolation(vs) =>
+          vs.collectFirst {
+            case exceptions.AppendConsistencyViolation.StreamConditionViolation(s, _, ActualCondition.Tombstoned) if targets(s) =>
+              exceptions.StreamTombstoned(s)
+          }.orElse(vs.collectFirst {
+            case exceptions.AppendConsistencyViolation.StreamConditionViolation(s, _, ActualCondition.SoftDeleted) if targets(s) =>
+              exceptions.StreamDeleted(s)
+          }).getOrElse(exceptions.AppendConsistencyViolation(vs))
+      }
 
   private[sec] def delete0[F[_]: Temporal](
     streamId: StreamId,

--- a/tests/src/fit/scala/sec/api/streams/multiStreamAppend.scala
+++ b/tests/src/fit/scala/sec/api/streams/multiStreamAppend.scala
@@ -241,7 +241,10 @@ class MultiStreamAppendSuite extends FSuite:
         case Left(v: exceptions.AppendConsistencyViolation) =>
           assertEquals(
             v.violations.map(x => (x.streamId, x.expected, x.actual)).toSet,
-            Set((aId.stringValue, -4L, -1L), (bId.stringValue, -4L, -1L))
+            Set(
+              (aId.stringValue, ExpectedCondition.StreamExists, ActualCondition.NotFound),
+              (bId.stringValue, ExpectedCondition.StreamExists, ActualCondition.NotFound)
+            )
           )
         case other => fail(s"expected AppendConsistencyViolation with both streams, got $other")
       }
@@ -271,7 +274,9 @@ class MultiStreamAppendSuite extends FSuite:
                  case Left(v: exceptions.AppendConsistencyViolation) =>
                    assertEquals(
                      v.violations.map(x => (x.streamId, x.expected, x.actual)),
-                     List((cId.stringValue, 5L, 0L))
+                     List(
+                       (cId.stringValue, ExpectedCondition.AtPosition(StreamPosition(5L)), ActualCondition.AtPosition(StreamPosition(0L)))
+                     )
                    )
                  case other => fail(s"expected violation with exact expected/actual, got $other"))
         ok  <- append(StreamPosition(0L))
@@ -280,7 +285,7 @@ class MultiStreamAppendSuite extends FSuite:
     }
   }
 
-  test("appends to tombstoned streams fail as a consistency violation") {
+  test("appends to tombstoned streams are promoted to StreamTombstoned") {
     mkClient().use { client =>
       import cats.data.NonEmptyList as CNel
 
@@ -293,10 +298,9 @@ class MultiStreamAppendSuite extends FSuite:
         Properties.empty
       )
 
-      // The server refuses an append to a tombstoned stream as a consistency violation whose
-      // actual state is the Tombstoned sentinel (-6), not a tombstone-typed detail, so convertV2
-      // surfaces AppendConsistencyViolation rather than StreamTombstoned. (The dotnet client
-      // promotes actual -6/-5 to a typed exception; sec does not yet - see follow-up.)
+      // The server refuses an append to a tombstoned stream as a consistency violation whose actual
+      // condition is Tombstoned; multiStreamAppend0 promotes that to StreamTombstoned for an append
+      // target (a guard would keep the AppendConsistencyViolation).
       for
         _   <- client.streams.appendToStream(dId, StreamState.NoStream, genEvents(1))
         _   <- client.streams.tombstone(dId, StreamState.StreamExists)
@@ -304,9 +308,8 @@ class MultiStreamAppendSuite extends FSuite:
                  .multiStreamAppend(CNel.one(StreamAppend(dId, StreamState.NoStream, CNel.one(rec))))
                  .attempt
         _   <- IO(res match
-                 case Left(e: exceptions.AppendConsistencyViolation) =>
-                   assertEquals(e.violations.map(v => (v.streamId, v.expected, v.actual)), List((dId.stringValue, -1L, -6L)))
-                 case other => fail(s"expected AppendConsistencyViolation, got $other"))
+                 case Left(e: exceptions.StreamTombstoned) => assertEquals(e.streamId, dId.stringValue)
+                 case other => fail(s"expected StreamTombstoned, got $other"))
       yield ()
     }
   }
@@ -450,7 +453,7 @@ class MultiStreamAppendSuite extends FSuite:
                     grpc.convertV2.convertToEs(e) match
                       case Some(v: exceptions.AppendConsistencyViolation) =>
                         assertEquals(v.violations.map(_.streamId), List(a))
-                        assertEquals(v.violations.map(_.actual), List(0L))
+                        assertEquals(v.violations.map(_.actual), List(ActualCondition.AtPosition(StreamPosition(0L))))
                       case other => fail(s"expected AppendConsistencyViolation from convertV2, got $other")
                   case other => fail(s"expected StatusRuntimeException, got $other"))
         _    <- res.swap.toOption.traverse_ {

--- a/tests/src/test/scala/sec/api/grpc/convertV2.scala
+++ b/tests/src/test/scala/sec/api/grpc/convertV2.scala
@@ -47,13 +47,18 @@ class ConvertV2Suite extends SecSuite:
     )
     assertEquals(
       convertV2.convertToEs(sre(PbAny.pack(d))),
-      Some(AppendConsistencyViolation(List(AppendConsistencyViolation.StreamStateViolation("s1", -1L, 0L))))
+      Some(
+        AppendConsistencyViolation(
+          List(AppendConsistencyViolation.StreamConditionViolation("s1", ExpectedCondition.NoStream, ActualCondition.AtPosition(StreamPosition(0L))))
+        )
+      )
     )
   }
 
   test("revision conflict, size exceeded and stream lifecycle details map to their exceptions") {
     val cases: List[(PbAny, EsException)] = List(
-      PbAny.pack(v2e.StreamRevisionConflictErrorDetails("s", 3L, 5L)) -> StreamPositionConflict("s", 3L, 5L),
+      PbAny.pack(v2e.StreamRevisionConflictErrorDetails("s", 3L, 5L)) ->
+        StreamConditionMismatch("s", ExpectedCondition.AtPosition(StreamPosition(3L)), ActualCondition.AtPosition(StreamPosition(5L))),
       PbAny.pack(v2e.AppendRecordSizeExceededErrorDetails("s", "r", 10, 5)) ->
         AppendRecordSizeExceeded("s", "r", 10, 5),
       PbAny.pack(v2e.AppendTransactionSizeExceededErrorDetails(10, 5)) -> AppendTransactionSizeExceeded(10, 5),


### PR DESCRIPTION
Replace the raw Long sentinels on the append error details with two ADTs decoded in convertV2: ExpectedCondition (NoStream, StreamExists, SoftDeleted, Tombstoned, AtPosition) and ActualCondition (NotFound, SoftDeleted, Tombstoned, AtPosition). They are deliberately distinct - StreamExists is expectation-only, NotFound observation-only - mirroring the server's ExpectedStreamCondition/ ActualStreamCondition, and there is no expected Any case (the validator rejects it; Any is expressed as the absence of a check). Decoding is direction-aware (wire -1 is NoStream on the expected side, NotFound on the actual side) and treats any value outside the modelled domain as a decode-miss, so no sentinel leaks through the ADT.

Rename the now-misnamed carriers to suit: AppendConsistencyViolation's StreamStateViolation becomes StreamConditionViolation, and StreamPositionConflict becomes StreamConditionMismatch; both carry the conditions.

Promote a tombstoned or soft-deleted append target from a consistency violation to a typed StreamTombstoned/StreamDeleted in multiStreamAppend0, scoped to append targets - a guard keeps the violation - as the dotnet client does.

Verified against the server source: ConsistencyCheckValidator for the accepted expected values and StreamsService.MapViolations for the returned actual values.