### PR TITLE
feat: full property values and typed InvalidRequest from BadRequest

### DIFF
--- a/core/src/main/scala/sec/api/exceptions.scala
+++ b/core/src/main/scala/sec/api/exceptions.scala
@@ -17,6 +17,7 @@
 package sec
 package api
 
+import cats.data.NonEmptyList
 import scala.util.control.NoStackTrace
 
 object exceptions:
@@ -121,6 +122,17 @@ object exceptions:
 
   case class AppendTransactionSizeExceeded(size: Int, maxSize: Int)
     extends EsException(s"Append transaction is $size bytes, exceeding max of $maxSize.")
+
+  case class FieldViolation(field: String, description: String)
+
+  case class InvalidRequest(violations: NonEmptyList[FieldViolation])
+    extends EsException(InvalidRequest.mkMsg(violations))
+
+  object InvalidRequest:
+    private[sec] def mkMsg(vs: NonEmptyList[FieldViolation]): String =
+      vs.toList
+        .map(v => if v.field.isEmpty then v.description else s"${v.field}: ${v.description}")
+        .mkString("Request validation failed: ", "; ", ".")
 
   case class AppendConsistencyViolation(violations: List[AppendConsistencyViolation.StreamConditionViolation])
     extends EsException(AppendConsistencyViolation.mkMsg(violations))

--- a/core/src/main/scala/sec/api/grpc/convertV2.scala
+++ b/core/src/main/scala/sec/api/grpc/convertV2.scala
@@ -18,6 +18,7 @@ package sec
 package api
 package grpc
 
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 import com.google.protobuf.any.Any as PbAny
 import com.google.rpc.Status as PbStatus
@@ -73,7 +74,12 @@ private[sec] object convertV2:
       unpackAs[v2e.StreamAlreadyExistsErrorDetails](a).map(d => StreamAlreadyExists(d.stream)) orElse
       unpackAs[v2e.StreamTombstonedErrorDetails](a).map(d => StreamTombstoned(d.stream)) orElse
       unpackAs[v2e.StreamDeletedErrorDetails](a).map(d => StreamDeleted(d.stream)) orElse
-      unpackAs[v2e.StreamNotFoundErrorDetails](a).map(d => StreamNotFound(d.stream))
+      unpackAs[v2e.StreamNotFoundErrorDetails](a).map(d => StreamNotFound(d.stream)) orElse
+      unpackAs[com.google.rpc.BadRequest](a).flatMap { br =>
+        NonEmptyList
+          .fromList(br.fieldViolations.toList.map(fv => FieldViolation(fv.field, fv.description)))
+          .map(InvalidRequest(_))
+      }
 
   private def expectedCondition(v: Long): Option[ExpectedCondition] = v match
     case -1          => ExpectedCondition.NoStream.some

--- a/core/src/main/scala/sec/api/mapping/streamsV2.scala
+++ b/core/src/main/scala/sec/api/mapping/streamsV2.scala
@@ -44,9 +44,12 @@ private[sec] object streamsV2:
     case SchemaFormat.Bytes    => pv2.SchemaFormat.SCHEMA_FORMAT_BYTES
 
   def mkValue(p: PropertyValue): ps.Value = p match
+    case PropertyValue.Null    => ps.Value(ps.Value.Kind.NullValue(ps.NullValue.NULL_VALUE))
     case PropertyValue.Str(v)  => ps.Value(ps.Value.Kind.StringValue(v))
     case PropertyValue.Num(v)  => ps.Value(ps.Value.Kind.NumberValue(v))
     case PropertyValue.Bool(v) => ps.Value(ps.Value.Kind.BoolValue(v))
+    case PropertyValue.Arr(vs) => ps.Value(ps.Value.Kind.ListValue(ps.ListValue(vs.map(mkValue))))
+    case PropertyValue.Obj(fs) => ps.Value(ps.Value.Kind.StructValue(ps.Struct(fs.toMap.view.mapValues(mkValue).toMap)))
 
   def mkAppendRecord(streamId: StreamId.Id, r: RecordData): pv2.AppendRecord =
     pv2.AppendRecord(

--- a/core/src/main/scala/sec/api/multiAppend.scala
+++ b/core/src/main/scala/sec/api/multiAppend.scala
@@ -41,9 +41,12 @@ enum SchemaFormat:
   case Json, Protobuf, Avro, Bytes
 
 enum PropertyValue:
+  case Null
   case Str(value: String)
   case Num(value: Double)
   case Bool(value: Boolean)
+  case Arr(values: List[PropertyValue])
+  case Obj(fields: Properties)
 
 /** Validated user properties. Keys must be non-empty and must not use the reserved `$` prefix -
   * the server owns that namespace (`$schema.name`, `$schema.format`, ...).

--- a/docs/multi-append.md
+++ b/docs/multi-append.md
@@ -82,4 +82,5 @@ A violated expectation or guard raises `AppendConsistencyViolation`, naming each
 with its expected and actual state. Other failures surface as `StreamConditionMismatch`,
 `AppendRecordSizeExceeded`, `AppendTransactionSizeExceeded`, `StreamAlreadyExists`, or
 `StreamTombstoned`. Streams that do not exist or are deleted raise the same `StreamNotFound` and
-`StreamDeleted` as the v1 operations.
+`StreamDeleted` as the v1 operations. A malformed request - a duplicate stream, an empty property
+key - is rejected by the server as `InvalidRequest`, carrying the per-field violations.

--- a/protobuf/google/rpc/error_details.proto
+++ b/protobuf/google/rpc/error_details.proto
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/errdetails;errdetails";
+option java_multiple_files = true;
+option java_outer_classname = "ErrorDetailsProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// Describes violations in a client request. This error type focuses on the
+// syntactic aspects of the request.
+message BadRequest {
+  // A message type used to describe a single bad request field.
+  message FieldViolation {
+    // A path that leads to a field in the request body.
+    string field = 1;
+
+    // A description of why the request element is bad.
+    string description = 2;
+  }
+
+  // Describes all violations in a client request.
+  repeated FieldViolation field_violations = 1;
+}

--- a/tests/src/main/scala/sec/arbitraries.scala
+++ b/tests/src/main/scala/sec/arbitraries.scala
@@ -315,11 +315,23 @@ object arbitraries {
         format <- schemaFormat
       yield Schema(s"sec-$name", format)
 
-    val propertyValue: Gen[PropertyValue] = Gen.oneOf(
-      Gen.alphaNumStr.map(PropertyValue.Str(_)),
-      Arbitrary.arbitrary[Double].map(PropertyValue.Num(_)),
-      Arbitrary.arbitrary[Boolean].map(PropertyValue.Bool(_))
-    )
+    def propertyValueOf(depth: Int): Gen[PropertyValue] =
+      val scalar = Gen.oneOf(
+        Gen.const(PropertyValue.Null),
+        Gen.alphaNumStr.map(PropertyValue.Str(_)),
+        Arbitrary.arbitrary[Double].map(PropertyValue.Num(_)),
+        Arbitrary.arbitrary[Boolean].map(PropertyValue.Bool(_))
+      )
+      if depth <= 0 then scalar
+      else
+        Gen.oneOf(
+          scalar,
+          Gen.choose(0, 3).flatMap(Gen.listOfN(_, propertyValueOf(depth - 1))).map(PropertyValue.Arr(_)),
+          Gen.mapOf(Gen.zip(Gen.identifier, propertyValueOf(depth - 1)))
+            .map(m => PropertyValue.Obj(Properties.of(m.toList*).fold(sys.error, identity)))
+        )
+
+    val propertyValue: Gen[PropertyValue] = propertyValueOf(2)
 
     val properties: Gen[Properties] = Gen
       .mapOf(Gen.zip(Gen.identifier, propertyValue))

--- a/tests/src/test/scala/sec/api/grpc/convertV2.scala
+++ b/tests/src/test/scala/sec/api/grpc/convertV2.scala
@@ -18,6 +18,7 @@ package sec
 package api
 package grpc
 
+import cats.data.NonEmptyList
 import com.google.protobuf.any.Any as PbAny
 import com.google.rpc.Status as PbStatus
 import io.grpc.{Metadata, Status, StatusRuntimeException}
@@ -65,7 +66,10 @@ class ConvertV2Suite extends SecSuite:
       PbAny.pack(v2e.StreamAlreadyExistsErrorDetails("s"))             -> StreamAlreadyExists("s"),
       PbAny.pack(v2e.StreamTombstonedErrorDetails("s"))                -> StreamTombstoned("s"),
       PbAny.pack(v2e.StreamDeletedErrorDetails("s"))                   -> StreamDeleted("s"),
-      PbAny.pack(v2e.StreamNotFoundErrorDetails("s"))                  -> StreamNotFound("s")
+      PbAny.pack(v2e.StreamNotFoundErrorDetails("s"))                  -> StreamNotFound("s"),
+      PbAny.pack(
+        com.google.rpc.BadRequest(Seq(com.google.rpc.BadRequest.FieldViolation("checks", "each stream may appear once")))
+      ) -> InvalidRequest(NonEmptyList.one(FieldViolation("checks", "each stream may appear once")))
     )
     cases.foreach { case (any, expected) =>
       assertEquals(convertV2.convertToEs(sre(any)), Some(expected), s"for ${any.typeUrl}")


### PR DESCRIPTION
Expand PropertyValue from scalars to the full google.protobuf.Value shape: add Null, Arr and Obj (nested struct), mapped recursively in mkValue to the protobuf Struct encoding. A nested Obj reuses the validated Properties type, so keys are non-empty and non-$ at every level. The server only checks top-level keys (HasKindSet recurses through struct and list values, but the key NotEmpty rule does not - an apparent omission); sec applies the rule uniformly and keeps invalid states unrepresentable.

Decode the server's request-validation failures. A malformed request - a duplicate stream, an empty property key - comes back as InvalidArgument carrying a google.rpc.BadRequest detail; add that proto (vendored alongside the existing google.rpc protos), an InvalidRequest exception holding a NonEmptyList of FieldViolation(field, description), and a convertV2 branch that decodes it (empty violations is a decode-miss).

Verified against the server source: AppendRecordValidator and the request-validation layer that packs a google.rpc.BadRequest.